### PR TITLE
API additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ PolyhedralRelaxations.jl Change Log
 =========================
 
 ### Staged 
+- Update tests to conform to JuMP v0.22
+- Add on-off LP relaxations to the API
 - Add base name prefixes for constraints as optional arguments
 - Reuse partition variables in one relaxation to another 
 - Exposes the interval bisection partitioning API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PolyhedralRelaxations.jl Change Log
 =========================
 
 ### Staged 
-- Update tests to conform to JuMP v0.22
+- Update tests to conform to JuMP v0.22 and remove dependency on JuMP v0.21
 - Add on-off LP relaxations to the API
 - Add base name prefixes for constraints as optional arguments
 - Reuse partition variables in one relaxation to another 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ PolyhedralRelaxations.jl Change Log
 ### Staged 
 - Add base name prefixes for constraints as optional arguments
 - Reuse partition variables in one relaxation to another 
+- Exposes the interval bisection partitioning API
 
 ### v0.3.4
 - Allow for JuMP 1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 PolyhedralRelaxations.jl Change Log
 =========================
 
-### staged
+### Staged 
+- Add base name prefixes for constraints as optional arguments
 
 ### v0.3.4
 - Allow for JuMP 1.0
@@ -13,12 +14,13 @@ PolyhedralRelaxations.jl Change Log
 ### v0.3.3
 - Allow for JuMP 0.23
 
+
 ### v0.3.2
 - Allow for JuMP 0.22
 
 ### v0.3.1
 - Documentation updates
-- Adds base name prefixes as optional argument
+- Add base name prefixes as optional argument
 - Memento version update
 
 ### v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ PolyhedralRelaxations.jl Change Log
 
 ### Staged 
 - Add base name prefixes for constraints as optional arguments
+- Reuse partition variables in one relaxation to another 
 
 ### v0.3.4
 - Allow for JuMP 1.0

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -66,6 +66,22 @@ The partition refinement scheme is equipped with multiple stopping criteria that
 2. `num_additional_partitions`: this parameter as the name suggests will refine the partition using the interval bisection algorithm till the total number of additional partitions reaches this number. It's default value is set to 0. 
 
 The refinement algorithm will stop if either of the above two stopping criteria is satisfied. 
+The following example illustrates the API for refining the partition using interval-bisection for a univariate function. 
+
+```julia 
+using PolyhderalRelaxations, 
+partition = [1.0, 2.0]
+refine_partition!(x -> x^2, partition, num_additional_partitions=2)
+```
+
+The new partition would now be `[0.0, 0.5, 0.75, 1.0]`.
+
+## API for the partition refinement
+The API for partition refinement using interval bisection is as follows:
+
+```@docs 
+refine_partition!
+```
 
 ## Tolerance parameters
 The main functions to produce the relaxations are also equipped with the following two tolerance parameters:

--- a/src/api.jl
+++ b/src/api.jl
@@ -5,7 +5,7 @@ export construct_univariate_relaxation!,
 
 """
     construct_univariate_relaxation!(m,f,x,y,x_partition;f_dash=x->ForwardDiff.derivative(f,x),error_tolerance=NaN64,length_tolerance=1e-6,derivative_tolerance=1e-6,num_additional_partitions=0,
-    constraint_pre_base_name="",variable_pre_base_name="",use_formulation_info=FormulationInfo())
+    constraint_pre_base_name="",variable_pre_base_name="",formulation_info=FormulationInfo())
 
 Add MILP relaxation of `y=f(x)` to given JuMP model and return an object with
 new variables and constraints.
@@ -42,7 +42,7 @@ new variables and constraints.
     variables for meaningful LP files
 - `constraint_pre_base_name::AbstractString`: base_name that needs to be added to the constraints
     in the relaxation.
-- `use_formulation_info::FormulationInfo` : `FormulationInfo` for another univariate function on the 
+- `formulation_info::FormulationInfo` : `FormulationInfo` for another univariate function on the 
     same variable that can be reused for the current relaxation. 
 
 Assume that:

--- a/src/api.jl
+++ b/src/api.jl
@@ -37,7 +37,9 @@ new variables and constraints.
 - `variable_pre_base_name::AbstractString`: base_name that needs to be added to the auxiliary
     variables for meaningful LP files
 - `constraint_pre_base_name::AbstractString`: base_name that needs to be added to the constraints
-    in the relaxation
+    in the relaxation.
+- `use_formulation_info::FormulationInfo` : `FormulationInfo` for another univariate function on the 
+    same variable that can be reused for the current relaxation. 
 
 Assume that:
 - `f` is a bounded function of 1 variable.
@@ -61,7 +63,8 @@ function construct_univariate_relaxation!(
     derivative_tolerance::Float64 = EPS,
     num_additional_partitions::Int64 = 0,
     variable_pre_base_name::AbstractString = "",
-    constraint_pre_base_name::AbstractString = ""
+    constraint_pre_base_name::AbstractString = "",
+    formulation_info::FormulationInfo = FormulationInfo()
 )::FormulationInfo
     univariate_function_data = UnivariateFunctionData(
         f,
@@ -77,7 +80,10 @@ function construct_univariate_relaxation!(
     _validate(x, x_partition)
     _refine_partition!(univariate_function_data)
     func = milp ? _build_univariate_milp_relaxation! : _build_univariate_lp_relaxation!
-    return func(m, x, y, univariate_function_data, variable_pre_base_name, constraint_pre_base_name)
+    return func(m, x, y, univariate_function_data, 
+        variable_pre_base_name, 
+        constraint_pre_base_name, 
+        formulation_info)
 end
 
 """

--- a/src/api.jl
+++ b/src/api.jl
@@ -190,3 +190,69 @@ function construct_bilinear_relaxation!(
     return _build_bilinear_milp_relaxation!(m, x, y, z, x_partition, y_partition, 
         variable_pre_base_name, constraint_pre_base_name)
 end
+
+"""
+    construct_univariate_on_off_relaxation!(m,x,y,z,x_partition;
+    active_when_z_is_one=true,variable_pre_base_name="",constraint_pre_base_name="")
+
+Add a polyhedral relaxtion for `y = f(x)` when `z = 1` (`z = 0`) and `y = 0` when `z = 0` (`z = 1`).
+The choice of when the constraint should be active can be made using the boolean `active_when_z_is_one`.
+When `active_when_z_is_one` is set to `false`, `y = f(x)` when `z = 0` and `y = 0` when `z = 1`. 
+The function returns an object with new variables and constraints.
+
+# Mandatory Arguments
+- `m::Jump.Model`: model to which relaxation is to be added.
+- `f::Function`: function or oracle for which a polyhedral relaxation is
+    required, usually non-linear.
+- `x::Jump.VariableRef`: JuMP variable for domain of `f`.
+- `y::JuMP.VariableRef`: JuMP variable for evaluation of `f`.
+- `z::JuMP.VariableRef`: on-off JuMP variable 
+- `x_partition::Vector{<:Real}`: partition of the domain of `f`.
+    
+# Optional Arguments
+- `f_dash::Function`: function or oracle for derivative of `f`, defaults to 
+    the `derivative` function from the `ForwardDiff` package.
+- ` error_tolerance::Float64`: Maximum allowed vertical distance between over
+    and under estimators of `f`, defaults to NaN64.
+- `length_tolerance::Float64`: maximum length of a sub-interval in a partition,
+    defaults to ``1 \\times 10^{-6}``.
+- `derivative_tolerance::Float64`: minimum absolute difference between
+    derivaties at successive elements of a partition for them to be considered
+    different, defaults to ``1 \\times 10^{-6}``. If the difference of a partition sub-interval
+    is smaller than this value, that sub-interval will be refined.
+- `num_additional_partitions::Int64`: budget on number of sub-intervals in
+    partition, defaults to 0. Note that if the number of partitions is `n` and
+    the number of additional partitions is `m`, then the function will return a
+    relaxation with at most `n+m` partitions.
+- `active_when_z_is_one::Bool`: `y = f(x)` when `z = 1` (`z = 0`) 
+    and `y = 0` when `z = 0` (`z = 1`) if bool is set to true (false)
+- `variable_pre_base_name::AbstractString`: base_name that needs to be added to the auxiliary
+    variables for meaningful LP files
+- `constraint_pre_base_name::AbstractString`: base_name that needs to be added to the constraints
+    in the relaxation.
+
+Assume that:
+- `f` is a bounded function of 1 variable.
+- `x_partition` is a partition of the domain of `f` such that `f` is either
+    convex or concave each sub-interval of the partition.
+- `f_dash` is not equal at two consecutive elements of `x_partition`.
+    
+"""
+function construct_univariate_on_off_relaxation!(
+    m::JuMP.Model, 
+    f::Function,
+    x::JuMP.VariableRef, 
+    y::JuMP.VariableRef, 
+    z::JuMP.VariableRef,
+    x_partition::Vector{<:Real};
+    f_dash::Function = x -> ForwardDiff.derivative(f, x),
+    error_tolerance::Float64 = NaN64,
+    length_tolerance::Float64 = EPS,
+    derivative_tolerance::Float64 = EPS,
+    num_additional_partitions::Int64 = 0,
+    active_when_z_is_one::Bool=true,
+    variable_pre_base_name::AbstractString="",
+    constraint_pre_base_name::AbstractString=""
+)::FormulationInfo 
+
+end 

--- a/src/api.jl
+++ b/src/api.jl
@@ -269,6 +269,9 @@ function construct_univariate_on_off_relaxation!(
     _validate(x, x_partition)
     _validate(z)
     _refine_partition!(univariate_function_data)
-
-
+    return _build_univariate_on_off_relaxation!(m, x, y, z, 
+        univariate_function_data,
+        active_when_z_is_one, 
+        variable_pre_base_name, 
+        constraint_pre_base_name)
 end 

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,6 +1,7 @@
 export construct_univariate_relaxation!, 
     refine_partition!,
-    construct_bilinear_relaxation!
+    construct_bilinear_relaxation!,
+    construct_univariate_on_off_relaxation!
 
 """
     construct_univariate_relaxation!(m,f,x,y,x_partition;f_dash=x->ForwardDiff.derivative(f,x),error_tolerance=NaN64,length_tolerance=1e-6,derivative_tolerance=1e-6,num_additional_partitions=0,
@@ -254,5 +255,20 @@ function construct_univariate_on_off_relaxation!(
     variable_pre_base_name::AbstractString="",
     constraint_pre_base_name::AbstractString=""
 )::FormulationInfo 
+    univariate_function_data = UnivariateFunctionData(
+        f,
+        f_dash,
+        x_partition,
+        error_tolerance,
+        length_tolerance,
+        derivative_tolerance,
+        num_additional_partitions,
+        length(x_partition),
+    )
+    _validate(univariate_function_data)
+    _validate(x, x_partition)
+    _validate(z)
+    _refine_partition!(univariate_function_data)
+
 
 end 

--- a/src/api.jl
+++ b/src/api.jl
@@ -68,7 +68,7 @@ function construct_univariate_relaxation!(
     num_additional_partitions::Int64 = 0,
     variable_pre_base_name::AbstractString = "",
     constraint_pre_base_name::AbstractString = "",
-    formulation_info::FormulationInfo = FormulationInfo(),
+    formulation_info::FormulationInfo = FormulationInfo()
 )::FormulationInfo
     univariate_function_data = UnivariateFunctionData(
         f,
@@ -78,7 +78,7 @@ function construct_univariate_relaxation!(
         length_tolerance,
         derivative_tolerance,
         num_additional_partitions,
-        length(x_partition),
+        length(x_partition)
     )
     _validate(univariate_function_data)
     _validate(x, x_partition)
@@ -93,7 +93,7 @@ function construct_univariate_relaxation!(
         univariate_function_data,
         variable_pre_base_name,
         constraint_pre_base_name,
-        formulation_info,
+        formulation_info
     )
 end
 
@@ -146,7 +146,7 @@ function refine_partition!(
         length_tolerance,
         derivative_tolerance,
         num_additional_partitions,
-        length(partition),
+        length(partition)
     )
     _validate(univariate_function_data)
     return _refine_partition!(univariate_function_data)
@@ -171,6 +171,8 @@ new variables and constraints.
     variables for meaningful LP files
 - `constraint_pre_base_name::AbstractString`: base_name that needs to be added to the constraints
     in the relaxation
+- `formulation_info::FormulationInfo` : `FormulationInfo` for another bilinear function where the 
+    variables that is partitioned has to be same on both; to enable partition variable reuse
 
 
 This function builds an incremental formulation, and currently supports more than 
@@ -190,6 +192,7 @@ function construct_bilinear_relaxation!(
     y_partition::Vector{<:Real};
     variable_pre_base_name::AbstractString = "",
     constraint_pre_base_name::AbstractString = "",
+    formulation_info::FormulationInfo = FormulationInfo()
 )::FormulationInfo
     _validate(x, y, x_partition, y_partition)
     if length(x_partition) == 2 && length(y_partition) == 2
@@ -198,7 +201,7 @@ function construct_bilinear_relaxation!(
             x,
             y,
             z,
-            constraint_pre_base_name,
+            constraint_pre_base_name
         )
     end
     return _build_bilinear_milp_relaxation!(
@@ -210,6 +213,7 @@ function construct_bilinear_relaxation!(
         y_partition,
         variable_pre_base_name,
         constraint_pre_base_name,
+        formulation_info
     )
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -36,6 +36,8 @@ new variables and constraints.
     relaxation with at most `n+m` partitions.
 - `variable_pre_base_name::AbstractString`: base_name that needs to be added to the auxiliary
     variables for meaningful LP files
+- `constraint_pre_base_name::AbstractString`: base_name that needs to be added to the constraints
+    in the relaxation
 
 Assume that:
 - `f` is a bounded function of 1 variable.
@@ -59,6 +61,7 @@ function construct_univariate_relaxation!(
     derivative_tolerance::Float64 = EPS,
     num_additional_partitions::Int64 = 0,
     variable_pre_base_name::AbstractString = "",
+    constraint_pre_base_name::AbstractString = ""
 )::FormulationInfo
     univariate_function_data = UnivariateFunctionData(
         f,
@@ -73,10 +76,8 @@ function construct_univariate_relaxation!(
     _validate(univariate_function_data)
     _validate(x, x_partition)
     _refine_partition!(univariate_function_data)
-    func =
-        milp ? _build_univariate_milp_relaxation! :
-        _build_univariate_lp_relaxation!
-    return func(m, x, y, univariate_function_data, variable_pre_base_name)
+    func = milp ? _build_univariate_milp_relaxation! : _build_univariate_lp_relaxation!
+    return func(m, x, y, univariate_function_data, variable_pre_base_name, constraint_pre_base_name)
 end
 
 """
@@ -96,6 +97,8 @@ new variables and constraints.
 # Optional Arguments
 - `variable_pre_base_name::AbstractString`: base_name that needs to be added to the auxiliary
     variables for meaningful LP files
+- `constraint_pre_base_name::AbstractString`: base_name that needs to be added to the constraints
+    in the relaxation
 
 
 This function builds an incremental formulation, and currently supports more than 
@@ -114,18 +117,12 @@ function construct_bilinear_relaxation!(
     x_partition::Vector{<:Real},
     y_partition::Vector{<:Real};
     variable_pre_base_name::AbstractString = "",
+    constraint_pre_base_name::AbstractString = ""
 )::FormulationInfo
     _validate(x, y, x_partition, y_partition)
     if length(x_partition) == 2 && length(y_partition) == 2
-        return _build_mccormick_relaxation!(m, x, y, z)
+        return _build_mccormick_relaxation!(m, x, y, z, constraint_pre_base_name)
     end
-    return _build_bilinear_milp_relaxation!(
-        m,
-        x,
-        y,
-        z,
-        x_partition,
-        y_partition,
-        variable_pre_base_name,
-    )
+    return _build_bilinear_milp_relaxation!(m, x, y, z, x_partition, y_partition, 
+        variable_pre_base_name, constraint_pre_base_name)
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,4 +1,4 @@
-export construct_univariate_relaxation!, 
+export construct_univariate_relaxation!,
     refine_partition!,
     construct_bilinear_relaxation!,
     construct_univariate_on_off_relaxation!
@@ -68,7 +68,7 @@ function construct_univariate_relaxation!(
     num_additional_partitions::Int64 = 0,
     variable_pre_base_name::AbstractString = "",
     constraint_pre_base_name::AbstractString = "",
-    formulation_info::FormulationInfo = FormulationInfo()
+    formulation_info::FormulationInfo = FormulationInfo(),
 )::FormulationInfo
     univariate_function_data = UnivariateFunctionData(
         f,
@@ -83,11 +83,18 @@ function construct_univariate_relaxation!(
     _validate(univariate_function_data)
     _validate(x, x_partition)
     _refine_partition!(univariate_function_data)
-    func = milp ? _build_univariate_milp_relaxation! : _build_univariate_lp_relaxation!
-    return func(m, x, y, univariate_function_data, 
-        variable_pre_base_name, 
-        constraint_pre_base_name, 
-        formulation_info)
+    func =
+        milp ? _build_univariate_milp_relaxation! :
+        _build_univariate_lp_relaxation!
+    return func(
+        m,
+        x,
+        y,
+        univariate_function_data,
+        variable_pre_base_name,
+        constraint_pre_base_name,
+        formulation_info,
+    )
 end
 
 """
@@ -130,7 +137,7 @@ function refine_partition!(
     length_tolerance::Float64 = EPS,
     derivative_tolerance::Float64 = EPS,
     num_additional_partitions::Int64 = 0,
-)   
+)
     univariate_function_data = UnivariateFunctionData(
         f,
         f_dash,
@@ -139,11 +146,11 @@ function refine_partition!(
         length_tolerance,
         derivative_tolerance,
         num_additional_partitions,
-        length(partition)
+        length(partition),
     )
     _validate(univariate_function_data)
-    _refine_partition!(univariate_function_data)
-end 
+    return _refine_partition!(univariate_function_data)
+end
 
 """
     construct_bilinear_relaxation!(m,x,y,z,x_partition,y_partition)
@@ -182,14 +189,28 @@ function construct_bilinear_relaxation!(
     x_partition::Vector{<:Real},
     y_partition::Vector{<:Real};
     variable_pre_base_name::AbstractString = "",
-    constraint_pre_base_name::AbstractString = ""
+    constraint_pre_base_name::AbstractString = "",
 )::FormulationInfo
     _validate(x, y, x_partition, y_partition)
     if length(x_partition) == 2 && length(y_partition) == 2
-        return _build_mccormick_relaxation!(m, x, y, z, constraint_pre_base_name)
+        return _build_mccormick_relaxation!(
+            m,
+            x,
+            y,
+            z,
+            constraint_pre_base_name,
+        )
     end
-    return _build_bilinear_milp_relaxation!(m, x, y, z, x_partition, y_partition, 
-        variable_pre_base_name, constraint_pre_base_name)
+    return _build_bilinear_milp_relaxation!(
+        m,
+        x,
+        y,
+        z,
+        x_partition,
+        y_partition,
+        variable_pre_base_name,
+        constraint_pre_base_name,
+    )
 end
 
 """
@@ -240,10 +261,10 @@ Assume that:
     
 """
 function construct_univariate_on_off_relaxation!(
-    m::JuMP.Model, 
+    m::JuMP.Model,
     f::Function,
-    x::JuMP.VariableRef, 
-    y::JuMP.VariableRef, 
+    x::JuMP.VariableRef,
+    y::JuMP.VariableRef,
     z::JuMP.VariableRef,
     x_partition::Vector{<:Real};
     f_dash::Function = x -> ForwardDiff.derivative(f, x),
@@ -251,10 +272,10 @@ function construct_univariate_on_off_relaxation!(
     length_tolerance::Float64 = EPS,
     derivative_tolerance::Float64 = EPS,
     num_additional_partitions::Int64 = 0,
-    active_when_z_is_one::Bool=true,
-    variable_pre_base_name::AbstractString="",
-    constraint_pre_base_name::AbstractString=""
-)::FormulationInfo 
+    active_when_z_is_one::Bool = true,
+    variable_pre_base_name::AbstractString = "",
+    constraint_pre_base_name::AbstractString = "",
+)::FormulationInfo
     univariate_function_data = UnivariateFunctionData(
         f,
         f_dash,
@@ -269,9 +290,14 @@ function construct_univariate_on_off_relaxation!(
     _validate(x, x_partition)
     _validate(z)
     _refine_partition!(univariate_function_data)
-    return _build_univariate_on_off_relaxation!(m, x, y, z, 
+    return _build_univariate_on_off_relaxation!(
+        m,
+        x,
+        y,
+        z,
         univariate_function_data,
-        active_when_z_is_one, 
-        variable_pre_base_name, 
-        constraint_pre_base_name)
-end 
+        active_when_z_is_one,
+        variable_pre_base_name,
+        constraint_pre_base_name,
+    )
+end

--- a/src/bilinear_relaxation.jl
+++ b/src/bilinear_relaxation.jl
@@ -59,6 +59,7 @@ function _build_bilinear_milp_relaxation!(
     y_partition::Vector{<:Real},
     variable_pre_base_name::AbstractString,
     constraint_pre_base_name::AbstractString,
+    reuse::FormulationInfo
 )::FormulationInfo
     origin_vs, non_origin_vs =
         _collect_bilinear_vertices(x_partition, y_partition)

--- a/src/bilinear_relaxation.jl
+++ b/src/bilinear_relaxation.jl
@@ -14,25 +14,33 @@ function _build_mccormick_relaxation!(
     x::JuMP.VariableRef,
     y::JuMP.VariableRef,
     z::JuMP.VariableRef,
-    constraint_pre_base_name::AbstractString
+    constraint_pre_base_name::AbstractString,
 )::FormulationInfo
     x_lb, x_ub = _variable_domain(x)
     y_lb, y_ub = _variable_domain(y)
 
     formulation_info = FormulationInfo()
 
-    formulation_info.constraints[:lb_1] =
-        @constraint(m, z >= x_lb * y + y_lb * x - x_lb * y_lb, 
-            base_name = constraint_pre_base_name * "lb_1")
-    formulation_info.constraints[:lb_2] =
-        @constraint(m, z >= x_ub * y + y_ub * x - x_ub * y_ub, 
-            base_name = constraint_pre_base_name * "lb_2")
-    formulation_info.constraints[:ub_1] =
-        @constraint(m, z <= x_lb * y + y_ub * x - x_lb * y_ub,
-            base_name = constraint_pre_base_name * "ub_1")
-    formulation_info.constraints[:ub_2] =
-        @constraint(m, z <= x_ub * y + y_lb * x - x_ub * y_lb,
-            base_name = constraint_pre_base_name * "ub_2")
+    formulation_info.constraints[:lb_1] = @constraint(
+        m,
+        z >= x_lb * y + y_lb * x - x_lb * y_lb,
+        base_name = constraint_pre_base_name * "lb_1"
+    )
+    formulation_info.constraints[:lb_2] = @constraint(
+        m,
+        z >= x_ub * y + y_ub * x - x_ub * y_ub,
+        base_name = constraint_pre_base_name * "lb_2"
+    )
+    formulation_info.constraints[:ub_1] = @constraint(
+        m,
+        z <= x_lb * y + y_ub * x - x_lb * y_ub,
+        base_name = constraint_pre_base_name * "ub_1"
+    )
+    formulation_info.constraints[:ub_2] = @constraint(
+        m,
+        z <= x_ub * y + y_lb * x - x_ub * y_lb,
+        base_name = constraint_pre_base_name * "ub_2"
+    )
 
     return formulation_info
 end
@@ -50,7 +58,7 @@ function _build_bilinear_milp_relaxation!(
     x_partition::Vector{<:Real},
     y_partition::Vector{<:Real},
     variable_pre_base_name::AbstractString,
-    constraint_pre_base_name::AbstractString
+    constraint_pre_base_name::AbstractString,
 )::FormulationInfo
     origin_vs, non_origin_vs =
         _collect_bilinear_vertices(x_partition, y_partition)
@@ -59,23 +67,36 @@ function _build_bilinear_milp_relaxation!(
 
     # add variables
     delta_1 =
-        formulation_info.variables[:delta_1] =
-            @variable(m, [1:num_vars], 
-                lower_bound = 0.0, upper_bound = 1.0,
-                base_name = variable_pre_base_name * "delta_1")
+        formulation_info.variables[:delta_1] = @variable(
+            m,
+            [1:num_vars],
+            lower_bound = 0.0,
+            upper_bound = 1.0,
+            base_name = variable_pre_base_name * "delta_1"
+        )
     delta_2 =
-        formulation_info.variables[:delta_2] =
-            @variable(m, [1:num_vars], 
-                lower_bound = 0.0, upper_bound = 1.0,
-                base_name = variable_pre_base_name * "delta_2")
+        formulation_info.variables[:delta_2] = @variable(
+            m,
+            [1:num_vars],
+            lower_bound = 0.0,
+            upper_bound = 1.0,
+            base_name = variable_pre_base_name * "delta_2"
+        )
     delta_3 =
-        formulation_info.variables[:delta_3] =
-            @variable(m, [1:num_vars], 
-                lower_bound = 0.0, upper_bound = 1.0,
-                base_name = variable_pre_base_name * "delta_3")
-    z_bin = formulation_info.variables[:z_bin] = 
-        @variable(m, [1:num_vars], binary = true, 
-            base_name = variable_pre_base_name * "z")
+        formulation_info.variables[:delta_3] = @variable(
+            m,
+            [1:num_vars],
+            lower_bound = 0.0,
+            upper_bound = 1.0,
+            base_name = variable_pre_base_name * "delta_3"
+        )
+    z_bin =
+        formulation_info.variables[:z_bin] = @variable(
+            m,
+            [1:num_vars],
+            binary = true,
+            base_name = variable_pre_base_name * "z"
+        )
 
     # add x constraints
     formulation_info.constraints[:x] = @constraint(
@@ -84,7 +105,8 @@ function _build_bilinear_milp_relaxation!(
         origin_vs[1][1] + sum(
             delta_1[i] * (non_origin_vs[i][1] - origin_vs[i][1]) +
             delta_2[i] * (non_origin_vs[i+1][1] - origin_vs[i][1]) +
-            delta_3[i] * (origin_vs[i+1][1] - origin_vs[i][1]) for i = 1:num_vars
+            delta_3[i] * (origin_vs[i+1][1] - origin_vs[i][1]) for
+            i in 1:num_vars
         ),
         base_name = constraint_pre_base_name * "x"
     )
@@ -96,7 +118,8 @@ function _build_bilinear_milp_relaxation!(
         origin_vs[1][2] + sum(
             delta_1[i] * (non_origin_vs[i][2] - origin_vs[i][2]) +
             delta_2[i] * (non_origin_vs[i+1][2] - origin_vs[i][2]) +
-            delta_3[i] * (origin_vs[i+1][2] - origin_vs[i][2]) for i = 1:num_vars
+            delta_3[i] * (origin_vs[i+1][2] - origin_vs[i][2]) for
+            i in 1:num_vars
         ),
         base_name = constraint_pre_base_name * "y"
     )
@@ -108,23 +131,32 @@ function _build_bilinear_milp_relaxation!(
         origin_vs[1][3] + sum(
             delta_1[i] * (non_origin_vs[i][3] - origin_vs[i][3]) +
             delta_2[i] * (non_origin_vs[i+1][3] - origin_vs[i][3]) +
-            delta_3[i] * (origin_vs[i+1][3] - origin_vs[i][3]) for i = 1:num_vars
+            delta_3[i] * (origin_vs[i+1][3] - origin_vs[i][3]) for
+            i in 1:num_vars
         ),
         base_name = constraint_pre_base_name * "z_bin"
     )
 
     # add first delta constraint
-    formulation_info.constraints[:first_delta] =
-        @constraint(m, delta_1[1] + delta_2[1] + delta_3[1] <= 1,
-            base_name = constraint_pre_base_name * "first_delta")
+    formulation_info.constraints[:first_delta] = @constraint(
+        m,
+        delta_1[1] + delta_2[1] + delta_3[1] <= 1,
+        base_name = constraint_pre_base_name * "first_delta"
+    )
 
     # add linking constraints between delta_1, delta_2 and z
-    formulation_info.constraints[:below_z] =
-        @constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] + delta_3[i] <= z_bin[i-1],
-            base_name = constraint_pre_base_name * "below_z")
-    formulation_info.constraints[:above_z] =
-        @constraint(m, [i = 2:num_vars], z_bin[i-1] <= delta_3[i-1],
-            base_name = constraint_pre_base_name * "above_z")
+    formulation_info.constraints[:below_z] = @constraint(
+        m,
+        [i = 2:num_vars],
+        delta_1[i] + delta_2[i] + delta_3[i] <= z_bin[i-1],
+        base_name = constraint_pre_base_name * "below_z"
+    )
+    formulation_info.constraints[:above_z] = @constraint(
+        m,
+        [i = 2:num_vars],
+        z_bin[i-1] <= delta_3[i-1],
+        base_name = constraint_pre_base_name * "above_z"
+    )
 
     return formulation_info
 end

--- a/src/bilinear_relaxation.jl
+++ b/src/bilinear_relaxation.jl
@@ -14,6 +14,7 @@ function _build_mccormick_relaxation!(
     x::JuMP.VariableRef,
     y::JuMP.VariableRef,
     z::JuMP.VariableRef,
+    constraint_pre_base_name::AbstractString
 )::FormulationInfo
     x_lb, x_ub = _variable_domain(x)
     y_lb, y_ub = _variable_domain(y)
@@ -21,13 +22,17 @@ function _build_mccormick_relaxation!(
     formulation_info = FormulationInfo()
 
     formulation_info.constraints[:lb_1] =
-        @constraint(m, z >= x_lb * y + y_lb * x - x_lb * y_lb)
+        @constraint(m, z >= x_lb * y + y_lb * x - x_lb * y_lb, 
+            base_name = constraint_pre_base_name * "lb_1")
     formulation_info.constraints[:lb_2] =
-        @constraint(m, z >= x_ub * y + y_ub * x - x_ub * y_ub)
+        @constraint(m, z >= x_ub * y + y_ub * x - x_ub * y_ub, 
+            base_name = constraint_pre_base_name * "lb_2")
     formulation_info.constraints[:ub_1] =
-        @constraint(m, z <= x_lb * y + y_ub * x - x_lb * y_ub)
+        @constraint(m, z <= x_lb * y + y_ub * x - x_lb * y_ub,
+            base_name = constraint_pre_base_name * "ub_1")
     formulation_info.constraints[:ub_2] =
-        @constraint(m, z <= x_ub * y + y_lb * x - x_ub * y_lb)
+        @constraint(m, z <= x_ub * y + y_lb * x - x_ub * y_lb,
+            base_name = constraint_pre_base_name * "ub_2")
 
     return formulation_info
 end
@@ -44,7 +49,8 @@ function _build_bilinear_milp_relaxation!(
     z::JuMP.VariableRef,
     x_partition::Vector{<:Real},
     y_partition::Vector{<:Real},
-    pre_base_name::AbstractString,
+    variable_pre_base_name::AbstractString,
+    constraint_pre_base_name::AbstractString
 )::FormulationInfo
     origin_vs, non_origin_vs =
         _collect_bilinear_vertices(x_partition, y_partition)
@@ -53,36 +59,23 @@ function _build_bilinear_milp_relaxation!(
 
     # add variables
     delta_1 =
-        formulation_info.variables[:delta_1] = @variable(
-            m,
-            [1:num_vars],
-            lower_bound = 0.0,
-            upper_bound = 1.0,
-            base_name = pre_base_name * "delta_1"
-        )
+        formulation_info.variables[:delta_1] =
+            @variable(m, [1:num_vars], 
+                lower_bound = 0.0, upper_bound = 1.0,
+                base_name = variable_pre_base_name * "delta_1")
     delta_2 =
-        formulation_info.variables[:delta_2] = @variable(
-            m,
-            [1:num_vars],
-            lower_bound = 0.0,
-            upper_bound = 1.0,
-            base_name = pre_base_name * "delta_2"
-        )
+        formulation_info.variables[:delta_2] =
+            @variable(m, [1:num_vars], 
+                lower_bound = 0.0, upper_bound = 1.0,
+                base_name = variable_pre_base_name * "delta_2")
     delta_3 =
-        formulation_info.variables[:delta_3] = @variable(
-            m,
-            [1:num_vars],
-            lower_bound = 0.0,
-            upper_bound = 1.0,
-            base_name = pre_base_name * "delta_3"
-        )
-    z_bin =
-        formulation_info.variables[:z_bin] = @variable(
-            m,
-            [1:num_vars],
-            binary = true,
-            base_name = pre_base_name * "z"
-        )
+        formulation_info.variables[:delta_3] =
+            @variable(m, [1:num_vars], 
+                lower_bound = 0.0, upper_bound = 1.0,
+                base_name = variable_pre_base_name * "delta_3")
+    z_bin = formulation_info.variables[:z_bin] = 
+        @variable(m, [1:num_vars], binary = true, 
+            base_name = variable_pre_base_name * "z")
 
     # add x constraints
     formulation_info.constraints[:x] = @constraint(
@@ -91,9 +84,9 @@ function _build_bilinear_milp_relaxation!(
         origin_vs[1][1] + sum(
             delta_1[i] * (non_origin_vs[i][1] - origin_vs[i][1]) +
             delta_2[i] * (non_origin_vs[i+1][1] - origin_vs[i][1]) +
-            delta_3[i] * (origin_vs[i+1][1] - origin_vs[i][1]) for
-            i in 1:num_vars
-        )
+            delta_3[i] * (origin_vs[i+1][1] - origin_vs[i][1]) for i = 1:num_vars
+        ),
+        base_name = constraint_pre_base_name * "x"
     )
 
     # add y constraints
@@ -103,9 +96,9 @@ function _build_bilinear_milp_relaxation!(
         origin_vs[1][2] + sum(
             delta_1[i] * (non_origin_vs[i][2] - origin_vs[i][2]) +
             delta_2[i] * (non_origin_vs[i+1][2] - origin_vs[i][2]) +
-            delta_3[i] * (origin_vs[i+1][2] - origin_vs[i][2]) for
-            i in 1:num_vars
-        )
+            delta_3[i] * (origin_vs[i+1][2] - origin_vs[i][2]) for i = 1:num_vars
+        ),
+        base_name = constraint_pre_base_name * "y"
     )
 
     # add z constraints
@@ -115,23 +108,23 @@ function _build_bilinear_milp_relaxation!(
         origin_vs[1][3] + sum(
             delta_1[i] * (non_origin_vs[i][3] - origin_vs[i][3]) +
             delta_2[i] * (non_origin_vs[i+1][3] - origin_vs[i][3]) +
-            delta_3[i] * (origin_vs[i+1][3] - origin_vs[i][3]) for
-            i in 1:num_vars
-        )
+            delta_3[i] * (origin_vs[i+1][3] - origin_vs[i][3]) for i = 1:num_vars
+        ),
+        base_name = constraint_pre_base_name * "z_bin"
     )
 
     # add first delta constraint
     formulation_info.constraints[:first_delta] =
-        @constraint(m, delta_1[1] + delta_2[1] + delta_3[1] <= 1)
+        @constraint(m, delta_1[1] + delta_2[1] + delta_3[1] <= 1,
+            base_name = constraint_pre_base_name * "first_delta")
 
     # add linking constraints between delta_1, delta_2 and z
-    formulation_info.constraints[:below_z] = @constraint(
-        m,
-        [i = 2:num_vars],
-        delta_1[i] + delta_2[i] + delta_3[i] <= z_bin[i-1]
-    )
+    formulation_info.constraints[:below_z] =
+        @constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] + delta_3[i] <= z_bin[i-1],
+            base_name = constraint_pre_base_name * "below_z")
     formulation_info.constraints[:above_z] =
-        @constraint(m, [i = 2:num_vars], z_bin[i-1] <= delta_3[i-1])
+        @constraint(m, [i = 2:num_vars], z_bin[i-1] <= delta_3[i-1],
+            base_name = constraint_pre_base_name * "above_z")
 
     return formulation_info
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -160,6 +160,23 @@ function _variable_domain(var::JuMP.VariableRef)
 end
 
 """
+    _validate(x)
+
+Binary variable bounds checker  
+"""
+function _validate(x::JuMP.VariableRef)
+    x_lb, x_ub = _variable_domain(x)
+    if isfinite(x_lb) && x_lb != 0.0 
+        Memento.error(_LOGGER, "on-off variable's lower bound is non-zero, set it to zero")
+    end 
+    if isfinite(x_ub) && x_ub != 1.0
+        Memento.error(_LOGGER, "on-off variable's upper bound is not 1, set it to 1")
+    end 
+    (isinf(x_lb)) && (JuMP.set_lower_bound(x, 0.0))
+    (isinf(x_ub)) && (JuMP.set_upper_bound(x, 1.0))
+end 
+
+"""
     _validate(x, partition)
 
 Variable bounds and partition consistency checker

--- a/src/common.jl
+++ b/src/common.jl
@@ -166,15 +166,21 @@ Binary variable bounds checker
 """
 function _validate(x::JuMP.VariableRef)
     x_lb, x_ub = _variable_domain(x)
-    if isfinite(x_lb) && x_lb != 0.0 
-        Memento.error(_LOGGER, "on-off variable's lower bound is non-zero, set it to zero")
-    end 
+    if isfinite(x_lb) && x_lb != 0.0
+        Memento.error(
+            _LOGGER,
+            "on-off variable's lower bound is non-zero, set it to zero",
+        )
+    end
     if isfinite(x_ub) && x_ub != 1.0
-        Memento.error(_LOGGER, "on-off variable's upper bound is not 1, set it to 1")
-    end 
+        Memento.error(
+            _LOGGER,
+            "on-off variable's upper bound is not 1, set it to 1",
+        )
+    end
     (isinf(x_lb)) && (JuMP.set_lower_bound(x, 0.0))
-    (isinf(x_ub)) && (JuMP.set_upper_bound(x, 1.0))
-end 
+    return (isinf(x_ub)) && (JuMP.set_upper_bound(x, 1.0))
+end
 
 """
     _validate(x, partition)
@@ -220,14 +226,10 @@ end
 
 Input data point validator
 """
-<<<<<<< HEAD
 function _validate_point(
     univariate_function_data::UnivariateFunctionData,
-    x::Float64,
+    x::Real,
 )
-=======
-function _validate_point(univariate_function_data::UnivariateFunctionData, x::Real)
->>>>>>> exposes partition refinement as an API
     if !isfinite(x) || abs(x) >= INF
         error("all partition points must be finite")
     end

--- a/src/common.jl
+++ b/src/common.jl
@@ -203,10 +203,14 @@ end
 
 Input data point validator
 """
+<<<<<<< HEAD
 function _validate_point(
     univariate_function_data::UnivariateFunctionData,
     x::Float64,
 )
+=======
+function _validate_point(univariate_function_data::UnivariateFunctionData, x::Real)
+>>>>>>> exposes partition refinement as an API
     if !isfinite(x) || abs(x) >= INF
         error("all partition points must be finite")
     end
@@ -402,7 +406,7 @@ end
 Get error bound of a function with derivative `derivative` in the closed
 interval `[lb,ub]`.
 """
-function _get_error_bound(derivative::Function, lb::Float64, ub::Float64)
+function _get_error_bound(derivative::Function, lb::Real, ub::Real)
     return (ub - lb) * abs(derivative(ub) - derivative(lb)) / 4.0
 end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -425,26 +425,3 @@ function _get_max_error_bound(
     end
     return max_err
 end
-
-"""
-    _check_consistency(formulation_info, num_vars, milp) 
-
-Checks consistency between provided variables and partition sizes 
-""" 
-function _check_consistency(formulation_info::FormulationInfo, num_vars, milp::Bool)::Bool 
-    var = formulation_info.variables 
-    if milp
-        if haskey(var, :z)
-            (length(var[:z]) == num_vars) && (return true)
-            return false
-        end 
-        return false 
-    else 
-        if haskey(var, :lambda)
-            (length(var[:lambda]) == num_vars) && (return true)
-            return false 
-        end 
-        return false
-    end 
-    return false
-end 

--- a/src/common.jl
+++ b/src/common.jl
@@ -425,3 +425,26 @@ function _get_max_error_bound(
     end
     return max_err
 end
+
+"""
+    _check_consistency(formulation_info, num_vars, milp) 
+
+Checks consistency between provided variables and partition sizes 
+""" 
+function _check_consistency(formulation_info::FormulationInfo, num_vars, milp::Bool)::Bool 
+    var = formulation_info.variables 
+    if milp
+        if haskey(var, :z)
+            (length(var[:z]) == num_vars) && (return true)
+            return false
+        end 
+        return false 
+    else 
+        if haskey(var, :lambda)
+            (length(var[:lambda]) == num_vars) && (return true)
+            return false 
+        end 
+        return false
+    end 
+    return false
+end 

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -28,7 +28,7 @@ end
 """
     silence!()
 
-Sets loglevel for PMD to :Error, silencing Info and Warn
+Sets loglevel for PR to :Error, silencing Info and Warn
 """
 function silence!()
     return set_logging_level!(:Error)
@@ -48,7 +48,7 @@ end
 """
     restore_global_logger!()
 
-Restores the global logger to its default state (before PMD was loaded)
+Restores the global logger to its default state (before PR was loaded)
 """
 function restore_global_logger!()
     Logging.global_logger(_DEFAULT_LOGGER)
@@ -70,7 +70,7 @@ end
 """
     _make_filtered_logger(level::Logging.LogLevel)
 
-Helper function to create the filtered logger for PMD
+Helper function to create the filtered logger for PR
 """
 function _make_filtered_logger(level)
     LoggingExtras.EarlyFilteredLogger(_LOGGER) do log

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -91,10 +91,29 @@ function _build_univariate_on_off_relaxation(
                 base_name = constraint_pre_base_name * "sum_lambda") 
         end 
 
-    # these constraints have to be converted to inequality constraints on two sides 
-    formulation_info.constraints[:x] = 
-        @constraint(m, x == sum(lambda[i] * vertices[i][1] for i = 1:num_vars), 
-            base_name = constraint_pre_base_name * "x")
+    # `x` constraints are slightly different because `x` has to be within its limit when `y=f(x)` is not active 
+    x_lb, x_ub = _variable_domain(x)
+    formulation_info.constraints[:x_lb] = 
+        if active_when_z_is_one == true
+            @constraint(m, x >= 
+                sum(lambda[i] * vertices[i][1] for i = 1:num_vars) + (1 - z) * x_lb, 
+                base_name = constraint_pre_base_name * "x_lb")
+        else 
+            @constraint(m, x >= 
+                sum(lambda[i] * vertices[i][1] for i = 1:num_vars) + z * x_lb, 
+                base_name = constraint_pre_base_name * "x_lb")
+        end
+    
+    formulation_info.constraints[:x_ub] = 
+        if active_when_z_is_one == true
+            @constraint(m, x <= 
+                sum(lambda[i] * vertices[i][1] for i = 1:num_vars) + (1 - z) * x_ub, 
+                base_name = constraint_pre_base_name * "x_ub")
+        else 
+            @constraint(m, x <= 
+                sum(lambda[i] * vertices[i][1] for i = 1:num_vars) + z * x_ub, 
+                base_name = constraint_pre_base_name * "x_ub")
+        end 
     
     formulation_info.constraints[:y] =
         @constraint(m, y == sum(lambda[i] * vertices[i][2] for i = 1:num_vars),

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -54,3 +54,51 @@ function _build_univariate_lp_relaxation!(
 
     return formulation_info
 end
+
+"""
+    _build_univariate_on_off_relaxation!(m, x, y, z, active_when_z_is_one, 
+        variable_pre_base_name, constraint_pre_base_name)
+
+Build on-off relaxation for ``y=f(x)`` given the univariate function data.
+"""
+function _build_univariate_on_off_relaxation(
+    m::JuMP.Model, 
+    x::JuMP.VariableRef, 
+    y::JuMP.VariableRef, 
+    z::JuMP.VariableRef, 
+    univariate_function_data::UnivariateFunctionData,
+    active_when_z_is_one::Bool,
+    variable_pre_base_name::AbstractString,
+    constraint_pre_base_name::AbstractString
+)::FormulationInfo
+    vertices = _get_lp_relaxation_vertices(univariate_function_data)
+    num_vars = length(vertices)
+    formulation_info = FormulationInfo()
+
+    # add variables 
+    lambda = @variable(m, [1:num_vars], 
+            lower_bound = 0.0, upper_bound = 1.0, 
+            base_name = variable_pre_base_name * "lambda")
+    formulation_info.variables[:lambda] = lambda
+
+    # add constraints 
+    formulation_info.constraints[:sum_lambda] = 
+        if active_when_z_is_one == true
+            @constraint(m, sum(lambda) == z,
+                base_name = constraint_pre_base_name * "sum_lambda") 
+        else 
+            @constraint(m, sum(lambda) == 1 - z,
+                base_name = constraint_pre_base_name * "sum_lambda") 
+        end 
+
+    # these constraints have to be converted to inequality constraints on two sides 
+    formulation_info.constraints[:x] = 
+        @constraint(m, x == sum(lambda[i] * vertices[i][1] for i = 1:num_vars), 
+            base_name = constraint_pre_base_name * "x")
+    
+    formulation_info.constraints[:y] =
+        @constraint(m, y == sum(lambda[i] * vertices[i][2] for i = 1:num_vars),
+            base_name = constraint_pre_base_name * "y")
+
+    return formulation_info
+end 

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -27,7 +27,7 @@ function _build_univariate_lp_relaxation!(
     univariate_function_data::UnivariateFunctionData,
     variable_pre_base_name::AbstractString,
     constraint_pre_base_name::AbstractString,
-    _::FormulationInfo
+    ::FormulationInfo
 )::FormulationInfo
     vertices = _get_lp_relaxation_vertices(univariate_function_data)
     num_vars = length(vertices)

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -27,32 +27,24 @@ function _build_univariate_lp_relaxation!(
     univariate_function_data::UnivariateFunctionData,
     variable_pre_base_name::AbstractString,
     constraint_pre_base_name::AbstractString,
-    reuse::FormulationInfo
+    _::FormulationInfo
 )::FormulationInfo
     vertices = _get_lp_relaxation_vertices(univariate_function_data)
     num_vars = length(vertices)
     formulation_info = FormulationInfo()
 
-    reuse_variables = reuse.variables 
-    reuse_constraints = reuse.constraints 
-
-    is_consistent = _check_consistency(reuse, num_vars, false)
-
     # add variables 
-    lambda = (is_consistent) ? reuse_variables[:lambda] :
-        @variable(m, [1:num_vars], 
+    lambda = @variable(m, [1:num_vars], 
             lower_bound = 0.0, upper_bound = 1.0, 
             base_name = variable_pre_base_name * "lambda")
     formulation_info.variables[:lambda] = lambda
 
     # add constraints 
-    formulation_info.constraints[:sum_lambda] = (is_consistent) ? 
-        reuse_constraints[:sum_lambda] :
+    formulation_info.constraints[:sum_lambda] = 
         @constraint(m, sum(lambda) == 1,
             base_name = constraint_pre_base_name * "sum_lambda") 
 
-    formulation_info.constraints[:x] = (is_consistent) ? 
-        reuse_constraints[:x] :
+    formulation_info.constraints[:x] = 
         @constraint(m, x == sum(lambda[i] * vertices[i][1] for i = 1:num_vars), 
             base_name = constraint_pre_base_name * "x")
 

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -26,26 +26,36 @@ function _build_univariate_lp_relaxation!(
     y::JuMP.VariableRef,
     univariate_function_data::UnivariateFunctionData,
     variable_pre_base_name::AbstractString,
-    constraint_pre_base_name::AbstractString
+    constraint_pre_base_name::AbstractString,
+    reuse::FormulationInfo
 )::FormulationInfo
     vertices = _get_lp_relaxation_vertices(univariate_function_data)
     num_vars = length(vertices)
     formulation_info = FormulationInfo()
 
+    reuse_variables = reuse.variables 
+    reuse_constraints = reuse.constraints 
+
+    is_consistent = _check_consistency(reuse, num_vars, false)
+
     # add variables 
-    lambda =
-        formulation_info.variables[:lambda] =
-            @variable(m, [1:num_vars], 
-                lower_bound = 0.0, upper_bound = 1.0, 
-                base_name = variable_pre_base_name * "lambda")
+    lambda = (is_consistent) ? reuse_variables[:lambda] :
+        @variable(m, [1:num_vars], 
+            lower_bound = 0.0, upper_bound = 1.0, 
+            base_name = variable_pre_base_name * "lambda")
     formulation_info.variables[:lambda] = lambda
 
     # add constraints 
-    formulation_info.constraints[:sum_lambda] = @constraint(m, sum(lambda) == 1,
-        base_name = constraint_pre_base_name * "sum_lambda")
-    formulation_info.constraints[:x] =
+    formulation_info.constraints[:sum_lambda] = (is_consistent) ? 
+        reuse_constraints[:sum_lambda] :
+        @constraint(m, sum(lambda) == 1,
+            base_name = constraint_pre_base_name * "sum_lambda") 
+
+    formulation_info.constraints[:x] = (is_consistent) ? 
+        reuse_constraints[:x] :
         @constraint(m, x == sum(lambda[i] * vertices[i][1] for i = 1:num_vars), 
             base_name = constraint_pre_base_name * "x")
+
     formulation_info.constraints[:y] =
         @constraint(m, y == sum(lambda[i] * vertices[i][2] for i = 1:num_vars),
             base_name = constraint_pre_base_name * "y")

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -27,30 +27,40 @@ function _build_univariate_lp_relaxation!(
     univariate_function_data::UnivariateFunctionData,
     variable_pre_base_name::AbstractString,
     constraint_pre_base_name::AbstractString,
-    ::FormulationInfo
+    ::FormulationInfo,
 )::FormulationInfo
     vertices = _get_lp_relaxation_vertices(univariate_function_data)
     num_vars = length(vertices)
     formulation_info = FormulationInfo()
 
     # add variables 
-    lambda = @variable(m, [1:num_vars], 
-            lower_bound = 0.0, upper_bound = 1.0, 
-            base_name = variable_pre_base_name * "lambda")
+    lambda = @variable(
+        m,
+        [1:num_vars],
+        lower_bound = 0.0,
+        upper_bound = 1.0,
+        base_name = variable_pre_base_name * "lambda"
+    )
     formulation_info.variables[:lambda] = lambda
 
     # add constraints 
-    formulation_info.constraints[:sum_lambda] = 
-        @constraint(m, sum(lambda) == 1,
-            base_name = constraint_pre_base_name * "sum_lambda") 
+    formulation_info.constraints[:sum_lambda] = @constraint(
+        m,
+        sum(lambda) == 1,
+        base_name = constraint_pre_base_name * "sum_lambda"
+    )
 
-    formulation_info.constraints[:x] = 
-        @constraint(m, x == sum(lambda[i] * vertices[i][1] for i = 1:num_vars), 
-            base_name = constraint_pre_base_name * "x")
+    formulation_info.constraints[:x] = @constraint(
+        m,
+        x == sum(lambda[i] * vertices[i][1] for i in 1:num_vars),
+        base_name = constraint_pre_base_name * "x"
+    )
 
-    formulation_info.constraints[:y] =
-        @constraint(m, y == sum(lambda[i] * vertices[i][2] for i = 1:num_vars),
-            base_name = constraint_pre_base_name * "y")
+    formulation_info.constraints[:y] = @constraint(
+        m,
+        y == sum(lambda[i] * vertices[i][2] for i in 1:num_vars),
+        base_name = constraint_pre_base_name * "y"
+    )
 
     return formulation_info
 end
@@ -62,62 +72,83 @@ end
 Build on-off relaxation for ``y=f(x)`` given the univariate function data.
 """
 function _build_univariate_on_off_relaxation(
-    m::JuMP.Model, 
-    x::JuMP.VariableRef, 
-    y::JuMP.VariableRef, 
-    z::JuMP.VariableRef, 
+    m::JuMP.Model,
+    x::JuMP.VariableRef,
+    y::JuMP.VariableRef,
+    z::JuMP.VariableRef,
     univariate_function_data::UnivariateFunctionData,
     active_when_z_is_one::Bool,
     variable_pre_base_name::AbstractString,
-    constraint_pre_base_name::AbstractString
+    constraint_pre_base_name::AbstractString,
 )::FormulationInfo
     vertices = _get_lp_relaxation_vertices(univariate_function_data)
     num_vars = length(vertices)
     formulation_info = FormulationInfo()
 
     # add variables 
-    lambda = @variable(m, [1:num_vars], 
-            lower_bound = 0.0, upper_bound = 1.0, 
-            base_name = variable_pre_base_name * "lambda")
+    lambda = @variable(
+        m,
+        [1:num_vars],
+        lower_bound = 0.0,
+        upper_bound = 1.0,
+        base_name = variable_pre_base_name * "lambda"
+    )
     formulation_info.variables[:lambda] = lambda
 
     # add constraints 
-    formulation_info.constraints[:sum_lambda] = 
-        if active_when_z_is_one == true
-            @constraint(m, sum(lambda) == z,
-                base_name = constraint_pre_base_name * "sum_lambda") 
-        else 
-            @constraint(m, sum(lambda) == 1 - z,
-                base_name = constraint_pre_base_name * "sum_lambda") 
-        end 
+    formulation_info.constraints[:sum_lambda] = if active_when_z_is_one == true
+        @constraint(
+            m,
+            sum(lambda) == z,
+            base_name = constraint_pre_base_name * "sum_lambda"
+        )
+    else
+        @constraint(
+            m,
+            sum(lambda) == 1 - z,
+            base_name = constraint_pre_base_name * "sum_lambda"
+        )
+    end
 
     # `x` constraints are slightly different because `x` has to be within its limit when `y=f(x)` is not active 
     x_lb, x_ub = _variable_domain(x)
-    formulation_info.constraints[:x_lb] = 
-        if active_when_z_is_one == true
-            @constraint(m, x >= 
-                sum(lambda[i] * vertices[i][1] for i = 1:num_vars) + (1 - z) * x_lb, 
-                base_name = constraint_pre_base_name * "x_lb")
-        else 
-            @constraint(m, x >= 
-                sum(lambda[i] * vertices[i][1] for i = 1:num_vars) + z * x_lb, 
-                base_name = constraint_pre_base_name * "x_lb")
-        end
-    
-    formulation_info.constraints[:x_ub] = 
-        if active_when_z_is_one == true
-            @constraint(m, x <= 
-                sum(lambda[i] * vertices[i][1] for i = 1:num_vars) + (1 - z) * x_ub, 
-                base_name = constraint_pre_base_name * "x_ub")
-        else 
-            @constraint(m, x <= 
-                sum(lambda[i] * vertices[i][1] for i = 1:num_vars) + z * x_ub, 
-                base_name = constraint_pre_base_name * "x_ub")
-        end 
-    
-    formulation_info.constraints[:y] =
-        @constraint(m, y == sum(lambda[i] * vertices[i][2] for i = 1:num_vars),
-            base_name = constraint_pre_base_name * "y")
+    formulation_info.constraints[:x_lb] = if active_when_z_is_one == true
+        @constraint(
+            m,
+            x >=
+            sum(lambda[i] * vertices[i][1] for i in 1:num_vars) +
+            (1 - z) * x_lb,
+            base_name = constraint_pre_base_name * "x_lb"
+        )
+    else
+        @constraint(
+            m,
+            x >= sum(lambda[i] * vertices[i][1] for i in 1:num_vars) + z * x_lb,
+            base_name = constraint_pre_base_name * "x_lb"
+        )
+    end
+
+    formulation_info.constraints[:x_ub] = if active_when_z_is_one == true
+        @constraint(
+            m,
+            x <=
+            sum(lambda[i] * vertices[i][1] for i in 1:num_vars) +
+            (1 - z) * x_ub,
+            base_name = constraint_pre_base_name * "x_ub"
+        )
+    else
+        @constraint(
+            m,
+            x <= sum(lambda[i] * vertices[i][1] for i in 1:num_vars) + z * x_ub,
+            base_name = constraint_pre_base_name * "x_ub"
+        )
+    end
+
+    formulation_info.constraints[:y] = @constraint(
+        m,
+        y == sum(lambda[i] * vertices[i][2] for i in 1:num_vars),
+        base_name = constraint_pre_base_name * "y"
+    )
 
     return formulation_info
-end 
+end

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -15,7 +15,8 @@ function _get_lp_relaxation_vertices(
 end
 
 """
-    _build_univariate_lp_relaxation!(m, x, y, univariate_function_data, pre_base_name)
+    _build_univariate_lp_relaxation!(m, x, y, univariate_function_data, 
+        variable_pre_base_name, constraint_pre_base_name)
 
 Build LP relaxation for ``y=f(x)`` given the univariate function data.
 """
@@ -24,7 +25,8 @@ function _build_univariate_lp_relaxation!(
     x::JuMP.VariableRef,
     y::JuMP.VariableRef,
     univariate_function_data::UnivariateFunctionData,
-    pre_base_name::AbstractString,
+    variable_pre_base_name::AbstractString,
+    constraint_pre_base_name::AbstractString
 )::FormulationInfo
     vertices = _get_lp_relaxation_vertices(univariate_function_data)
     num_vars = length(vertices)
@@ -32,21 +34,21 @@ function _build_univariate_lp_relaxation!(
 
     # add variables 
     lambda =
-        formulation_info.variables[:lambda] = @variable(
-            m,
-            [1:num_vars],
-            lower_bound = 0.0,
-            upper_bound = 1.0,
-            base_name = pre_base_name * "_lambda"
-        )
+        formulation_info.variables[:lambda] =
+            @variable(m, [1:num_vars], 
+                lower_bound = 0.0, upper_bound = 1.0, 
+                base_name = variable_pre_base_name * "lambda")
     formulation_info.variables[:lambda] = lambda
 
     # add constraints 
-    formulation_info.constraints[:sum_lambda] = @constraint(m, sum(lambda) == 1)
+    formulation_info.constraints[:sum_lambda] = @constraint(m, sum(lambda) == 1,
+        base_name = constraint_pre_base_name * "sum_lambda")
     formulation_info.constraints[:x] =
-        @constraint(m, x == sum(lambda[i] * vertices[i][1] for i in 1:num_vars))
+        @constraint(m, x == sum(lambda[i] * vertices[i][1] for i = 1:num_vars), 
+            base_name = constraint_pre_base_name * "x")
     formulation_info.constraints[:y] =
-        @constraint(m, y == sum(lambda[i] * vertices[i][2] for i in 1:num_vars))
+        @constraint(m, y == sum(lambda[i] * vertices[i][2] for i = 1:num_vars),
+            base_name = constraint_pre_base_name * "y")
 
     return formulation_info
 end

--- a/src/univariate_milp_relaxation.jl
+++ b/src/univariate_milp_relaxation.jl
@@ -10,7 +10,8 @@ function _build_univariate_milp_relaxation!(
     y::JuMP.VariableRef,
     univariate_function_data::UnivariateFunctionData,
     variable_pre_base_name::AbstractString,
-    constraint_pre_base_name::AbstractString
+    constraint_pre_base_name::AbstractString,
+    reuse::FormulationInfo
 )::FormulationInfo
     sec_vs, tan_vs = _collect_vertices(univariate_function_data)
     formulation_info = FormulationInfo()
@@ -18,30 +19,40 @@ function _build_univariate_milp_relaxation!(
     # create variables
     num_vars = length(univariate_function_data.partition) - 1
 
-    delta_1 =
-        formulation_info.variables[:delta_1] =
-            @variable(m, [1:num_vars], 
-                lower_bound = 0.0, upper_bound = 1.0,
-                base_name = variable_pre_base_name * "delta_1")
-    delta_2 =
-        formulation_info.variables[:delta_2] =
-            @variable(m, [1:num_vars], 
-                lower_bound = 0.0, upper_bound = 1.0,
-                base_name = variable_pre_base_name * "delta_2")
-    z = formulation_info.variables[:z] = 
+    reuse_variables = reuse.variables 
+    reuse_constraints = reuse.constraints 
+
+    is_consistent = _check_consistency(reuse, num_vars, true)
+
+    delta_1 = (is_consistent) ? reuse_variables[:delta_1] :
+        @variable(m, [1:num_vars], 
+            lower_bound = 0.0, upper_bound = 1.0,
+            base_name = variable_pre_base_name * "delta_1")
+    formulation_info.variables[:delta_1] = delta_1
+    
+    delta_2 = (is_consistent) ? reuse_variables[:delta_2] :
+        @variable(m, [1:num_vars], 
+            lower_bound = 0.0, upper_bound = 1.0,
+            base_name = variable_pre_base_name * "delta_2")
+    formulation_info.variables[:delta_2] = delta_2
+
+    z = (is_consistent) ? reuse_variables[:z] :
         @variable(m, [1:num_vars], binary = true, 
-        base_name = variable_pre_base_name * "_z")
+            base_name = variable_pre_base_name * "_z")
+    formulation_info.variables[:z] = z
 
     # add x constraints
-    formulation_info.constraints[:x] = @constraint(
-        m,
-        x ==
-        sec_vs[1][1] + sum(
-            delta_1[i] * (tan_vs[i][1] - sec_vs[i][1]) +
-            delta_2[i] * (sec_vs[i+1][1] - sec_vs[i][1]) for i = 1:num_vars
-        ),
-        base_name = constraint_pre_base_name * "x"
-    )
+    formulation_info.constraints[:x] = (is_consistent) ?
+        reuse_constraints[:x] :
+        @constraint(
+            m,
+            x ==
+            sec_vs[1][1] + sum(
+                delta_1[i] * (tan_vs[i][1] - sec_vs[i][1]) +
+                delta_2[i] * (sec_vs[i+1][1] - sec_vs[i][1]) for i = 1:num_vars
+            ),
+            base_name = constraint_pre_base_name * "x"
+        )
 
     # add y constraints
     formulation_info.constraints[:y] = @constraint(
@@ -55,15 +66,19 @@ function _build_univariate_milp_relaxation!(
     )
 
     # add first delta constraint
-    formulation_info.constraints[:first_delta] =
+    formulation_info.constraints[:first_delta] = (is_consistent) ?
+        reuse_constraints[:first_delta] :
         @constraint(m, delta_1[1] + delta_2[1] <= 1,
             base_name = constraint_pre_base_name * "first_delta")
 
     # add linking constraints between delta_1, delta_2 and z
-    formulation_info.constraints[:below_z] =
+    formulation_info.constraints[:below_z] = (is_consistent) ?
+        reuse_constraints[:below_z] :
         @constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] <= z[i-1],
             base_name = constraint_pre_base_name * "below_z")
-    formulation_info.constraints[:above_z] =
+
+    formulation_info.constraints[:above_z] = (is_consistent) ?
+        reuse_constraints[:above_z] :
         @constraint(m, [i = 2:num_vars], z[i-1] <= delta_2[i-1],
             base_name = constraint_pre_base_name * "above_z")
 

--- a/src/univariate_milp_relaxation.jl
+++ b/src/univariate_milp_relaxation.jl
@@ -1,5 +1,19 @@
 """
-    _build_univariate_milp_relaxation!(m,x,y,function_data,pre_base_name)
+    _check_consistency(formulation_info, num_vars) 
+
+Checks consistency between provided variables and partition sizes 
+""" 
+function _check_consistency(formulation_info::FormulationInfo, num_vars)::Bool 
+    var = formulation_info.variables 
+    if haskey(var, :z)
+        (length(var[:z]) == num_vars) && (return true)
+    end 
+    return false 
+end 
+
+"""
+    _build_univariate_milp_relaxation!(m, x, y, function_data,
+        variable_pre_base_name, constraint_pre_base_name, reuse)
 
 Return a MILPRelaxation object with constraint and RHS information of the MILP
 formulation of the polyhedral relaxation.
@@ -20,20 +34,17 @@ function _build_univariate_milp_relaxation!(
     num_vars = length(univariate_function_data.partition) - 1
 
     reuse_variables = reuse.variables 
-    reuse_constraints = reuse.constraints 
 
-    is_consistent = _check_consistency(reuse, num_vars, true)
+    is_consistent = _check_consistency(reuse, num_vars)
 
-    delta_1 = (is_consistent) ? reuse_variables[:delta_1] :
-        @variable(m, [1:num_vars], 
-            lower_bound = 0.0, upper_bound = 1.0,
-            base_name = variable_pre_base_name * "delta_1")
+    delta_1 = @variable(m, [1:num_vars], 
+        lower_bound = 0.0, upper_bound = 1.0,
+        base_name = variable_pre_base_name * "delta_1")
     formulation_info.variables[:delta_1] = delta_1
     
-    delta_2 = (is_consistent) ? reuse_variables[:delta_2] :
-        @variable(m, [1:num_vars], 
-            lower_bound = 0.0, upper_bound = 1.0,
-            base_name = variable_pre_base_name * "delta_2")
+    delta_2 = @variable(m, [1:num_vars], 
+        lower_bound = 0.0, upper_bound = 1.0,
+        base_name = variable_pre_base_name * "delta_2")
     formulation_info.variables[:delta_2] = delta_2
 
     z = (is_consistent) ? reuse_variables[:z] :
@@ -42,8 +53,7 @@ function _build_univariate_milp_relaxation!(
     formulation_info.variables[:z] = z
 
     # add x constraints
-    formulation_info.constraints[:x] = (is_consistent) ?
-        reuse_constraints[:x] :
+    formulation_info.constraints[:x] = 
         @constraint(
             m,
             x ==
@@ -66,19 +76,16 @@ function _build_univariate_milp_relaxation!(
     )
 
     # add first delta constraint
-    formulation_info.constraints[:first_delta] = (is_consistent) ?
-        reuse_constraints[:first_delta] :
+    formulation_info.constraints[:first_delta] = 
         @constraint(m, delta_1[1] + delta_2[1] <= 1,
             base_name = constraint_pre_base_name * "first_delta")
 
     # add linking constraints between delta_1, delta_2 and z
-    formulation_info.constraints[:below_z] = (is_consistent) ?
-        reuse_constraints[:below_z] :
+    formulation_info.constraints[:below_z] = 
         @constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] <= z[i-1],
             base_name = constraint_pre_base_name * "below_z")
 
-    formulation_info.constraints[:above_z] = (is_consistent) ?
-        reuse_constraints[:above_z] :
+    formulation_info.constraints[:above_z] = 
         @constraint(m, [i = 2:num_vars], z[i-1] <= delta_2[i-1],
             base_name = constraint_pre_base_name * "above_z")
 

--- a/src/univariate_milp_relaxation.jl
+++ b/src/univariate_milp_relaxation.jl
@@ -9,7 +9,8 @@ function _build_univariate_milp_relaxation!(
     x::JuMP.VariableRef,
     y::JuMP.VariableRef,
     univariate_function_data::UnivariateFunctionData,
-    pre_base_name::AbstractString,
+    variable_pre_base_name::AbstractString,
+    constraint_pre_base_name::AbstractString
 )::FormulationInfo
     sec_vs, tan_vs = _collect_vertices(univariate_function_data)
     formulation_info = FormulationInfo()
@@ -18,28 +19,18 @@ function _build_univariate_milp_relaxation!(
     num_vars = length(univariate_function_data.partition) - 1
 
     delta_1 =
-        formulation_info.variables[:delta_1] = @variable(
-            m,
-            [1:num_vars],
-            lower_bound = 0.0,
-            upper_bound = 1.0,
-            base_name = pre_base_name * "delta_1"
-        )
+        formulation_info.variables[:delta_1] =
+            @variable(m, [1:num_vars], 
+                lower_bound = 0.0, upper_bound = 1.0,
+                base_name = variable_pre_base_name * "delta_1")
     delta_2 =
-        formulation_info.variables[:delta_2] = @variable(
-            m,
-            [1:num_vars],
-            lower_bound = 0.0,
-            upper_bound = 1.0,
-            base_name = pre_base_name * "delta_2"
-        )
-    z =
-        formulation_info.variables[:z] = @variable(
-            m,
-            [1:num_vars],
-            binary = true,
-            base_name = pre_base_name * "z"
-        )
+        formulation_info.variables[:delta_2] =
+            @variable(m, [1:num_vars], 
+                lower_bound = 0.0, upper_bound = 1.0,
+                base_name = variable_pre_base_name * "delta_2")
+    z = formulation_info.variables[:z] = 
+        @variable(m, [1:num_vars], binary = true, 
+        base_name = variable_pre_base_name * "_z")
 
     # add x constraints
     formulation_info.constraints[:x] = @constraint(
@@ -47,8 +38,9 @@ function _build_univariate_milp_relaxation!(
         x ==
         sec_vs[1][1] + sum(
             delta_1[i] * (tan_vs[i][1] - sec_vs[i][1]) +
-            delta_2[i] * (sec_vs[i+1][1] - sec_vs[i][1]) for i in 1:num_vars
-        )
+            delta_2[i] * (sec_vs[i+1][1] - sec_vs[i][1]) for i = 1:num_vars
+        ),
+        base_name = constraint_pre_base_name * "x"
     )
 
     # add y constraints
@@ -57,19 +49,23 @@ function _build_univariate_milp_relaxation!(
         y ==
         sec_vs[1][2] + sum(
             delta_1[i] * (tan_vs[i][2] - sec_vs[i][2]) +
-            delta_2[i] * (sec_vs[i+1][2] - sec_vs[i][2]) for i in 1:num_vars
-        )
+            delta_2[i] * (sec_vs[i+1][2] - sec_vs[i][2]) for i = 1:num_vars
+        ),
+        base_name = constraint_pre_base_name * "y"
     )
 
     # add first delta constraint
     formulation_info.constraints[:first_delta] =
-        @constraint(m, delta_1[1] + delta_2[1] <= 1)
+        @constraint(m, delta_1[1] + delta_2[1] <= 1,
+            base_name = constraint_pre_base_name * "first_delta")
 
     # add linking constraints between delta_1, delta_2 and z
     formulation_info.constraints[:below_z] =
-        @constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] <= z[i-1])
+        @constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] <= z[i-1],
+            base_name = constraint_pre_base_name * "below_z")
     formulation_info.constraints[:above_z] =
-        @constraint(m, [i = 2:num_vars], z[i-1] <= delta_2[i-1])
+        @constraint(m, [i = 2:num_vars], z[i-1] <= delta_2[i-1],
+            base_name = constraint_pre_base_name * "above_z")
 
     return formulation_info
 end

--- a/src/univariate_milp_relaxation.jl
+++ b/src/univariate_milp_relaxation.jl
@@ -2,14 +2,14 @@
     _check_consistency(formulation_info, num_vars) 
 
 Checks consistency between provided variables and partition sizes 
-""" 
-function _check_consistency(formulation_info::FormulationInfo, num_vars)::Bool 
-    var = formulation_info.variables 
+"""
+function _check_consistency(formulation_info::FormulationInfo, num_vars)::Bool
+    var = formulation_info.variables
     if haskey(var, :z)
         (length(var[:z]) == num_vars) && (return true)
-    end 
-    return false 
-end 
+    end
+    return false
+end
 
 """
     _build_univariate_milp_relaxation!(m, x, y, function_data,
@@ -25,7 +25,7 @@ function _build_univariate_milp_relaxation!(
     univariate_function_data::UnivariateFunctionData,
     variable_pre_base_name::AbstractString,
     constraint_pre_base_name::AbstractString,
-    reuse::FormulationInfo
+    reuse::FormulationInfo,
 )::FormulationInfo
     sec_vs, tan_vs = _collect_vertices(univariate_function_data)
     formulation_info = FormulationInfo()
@@ -33,36 +33,48 @@ function _build_univariate_milp_relaxation!(
     # create variables
     num_vars = length(univariate_function_data.partition) - 1
 
-    reuse_variables = reuse.variables 
+    reuse_variables = reuse.variables
 
     is_consistent = _check_consistency(reuse, num_vars)
 
-    delta_1 = @variable(m, [1:num_vars], 
-        lower_bound = 0.0, upper_bound = 1.0,
-        base_name = variable_pre_base_name * "delta_1")
+    delta_1 = @variable(
+        m,
+        [1:num_vars],
+        lower_bound = 0.0,
+        upper_bound = 1.0,
+        base_name = variable_pre_base_name * "delta_1"
+    )
     formulation_info.variables[:delta_1] = delta_1
-    
-    delta_2 = @variable(m, [1:num_vars], 
-        lower_bound = 0.0, upper_bound = 1.0,
-        base_name = variable_pre_base_name * "delta_2")
+
+    delta_2 = @variable(
+        m,
+        [1:num_vars],
+        lower_bound = 0.0,
+        upper_bound = 1.0,
+        base_name = variable_pre_base_name * "delta_2"
+    )
     formulation_info.variables[:delta_2] = delta_2
 
-    z = (is_consistent) ? reuse_variables[:z] :
-        @variable(m, [1:num_vars], binary = true, 
-            base_name = variable_pre_base_name * "_z")
+    z =
+        (is_consistent) ? reuse_variables[:z] :
+        @variable(
+            m,
+            [1:num_vars],
+            binary = true,
+            base_name = variable_pre_base_name * "_z"
+        )
     formulation_info.variables[:z] = z
 
     # add x constraints
-    formulation_info.constraints[:x] = 
-        @constraint(
-            m,
-            x ==
-            sec_vs[1][1] + sum(
-                delta_1[i] * (tan_vs[i][1] - sec_vs[i][1]) +
-                delta_2[i] * (sec_vs[i+1][1] - sec_vs[i][1]) for i = 1:num_vars
-            ),
-            base_name = constraint_pre_base_name * "x"
-        )
+    formulation_info.constraints[:x] = @constraint(
+        m,
+        x ==
+        sec_vs[1][1] + sum(
+            delta_1[i] * (tan_vs[i][1] - sec_vs[i][1]) +
+            delta_2[i] * (sec_vs[i+1][1] - sec_vs[i][1]) for i in 1:num_vars
+        ),
+        base_name = constraint_pre_base_name * "x"
+    )
 
     # add y constraints
     formulation_info.constraints[:y] = @constraint(
@@ -70,24 +82,32 @@ function _build_univariate_milp_relaxation!(
         y ==
         sec_vs[1][2] + sum(
             delta_1[i] * (tan_vs[i][2] - sec_vs[i][2]) +
-            delta_2[i] * (sec_vs[i+1][2] - sec_vs[i][2]) for i = 1:num_vars
+            delta_2[i] * (sec_vs[i+1][2] - sec_vs[i][2]) for i in 1:num_vars
         ),
         base_name = constraint_pre_base_name * "y"
     )
 
     # add first delta constraint
-    formulation_info.constraints[:first_delta] = 
-        @constraint(m, delta_1[1] + delta_2[1] <= 1,
-            base_name = constraint_pre_base_name * "first_delta")
+    formulation_info.constraints[:first_delta] = @constraint(
+        m,
+        delta_1[1] + delta_2[1] <= 1,
+        base_name = constraint_pre_base_name * "first_delta"
+    )
 
     # add linking constraints between delta_1, delta_2 and z
-    formulation_info.constraints[:below_z] = 
-        @constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] <= z[i-1],
-            base_name = constraint_pre_base_name * "below_z")
+    formulation_info.constraints[:below_z] = @constraint(
+        m,
+        [i = 2:num_vars],
+        delta_1[i] + delta_2[i] <= z[i-1],
+        base_name = constraint_pre_base_name * "below_z"
+    )
 
-    formulation_info.constraints[:above_z] = 
-        @constraint(m, [i = 2:num_vars], z[i-1] <= delta_2[i-1],
-            base_name = constraint_pre_base_name * "above_z")
+    formulation_info.constraints[:above_z] = @constraint(
+        m,
+        [i = 2:num_vars],
+        z[i-1] <= delta_2[i-1],
+        base_name = constraint_pre_base_name * "above_z"
+    )
 
     return formulation_info
 end

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -43,20 +43,18 @@ end
 end
 
 @testset "test (interval-bisection) partition refining API" begin
-    PR.logger_config!("error")
+    PR.silence!()
     partition = [0.0, 1.0]
 
-    refine_partition!(a -> a^3, partition, num_additional_partitions=0)
+    refine_partition!(a -> a^3, partition, num_additional_partitions = 0)
     @test length(partition) == 2
 
-    refine_partition!(a -> a^3, partition, num_additional_partitions=2)
+    refine_partition!(a -> a^3, partition, num_additional_partitions = 2)
     @test length(partition) == 4
 
-    refine_partition!(a -> a^3, partition, num_additional_partitions=5)
+    refine_partition!(a -> a^3, partition, num_additional_partitions = 5)
     @test length(partition) == 9
 end
-
-
 
 @testset "test bilinear relaxation API (McCormick)" begin
     replicates = 10

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -42,6 +42,22 @@ end
     @test haskey(formulation_info.constraints, :y)
 end
 
+@testset "test (interval-bisection) partition refining API" begin
+    PR.logger_config!("error")
+    partition = [0.0, 1.0]
+
+    refine_partition!(a -> a^3, partition, num_additional_partitions=0)
+    @test length(partition) == 2
+
+    refine_partition!(a -> a^3, partition, num_additional_partitions=2)
+    @test length(partition) == 4
+
+    refine_partition!(a -> a^3, partition, num_additional_partitions=5)
+    @test length(partition) == 9
+end
+
+
+
 @testset "test bilinear relaxation API (McCormick)" begin
     replicates = 10
     tolerance = 1e-3

--- a/test/objective_tests.jl
+++ b/test/objective_tests.jl
@@ -43,7 +43,7 @@
             # Solve MILP relaxation.
             set_objective_sense(milp, s)
             optimize!(milp)
-            @test termination_status(milp) == MOI.OPTIMAL
+            @test termination_status(milp) == OPTIMAL
 
             # Verify that the solution is one of the candidate solutions in `sln_verts`.
             milp_obj = objective_value(milp)
@@ -63,7 +63,7 @@
             # same objective value as the MILP relaxation.
             JuMP.relax_integrality(milp)
             optimize!(milp)
-            @test termination_status(milp) == MOI.OPTIMAL
+            @test termination_status(milp) == OPTIMAL
             lp1_obj = objective_value(milp)
             @test milp_obj ≈ lp1_obj atol = tol
 


### PR DESCRIPTION
This PR adds the following:

1. ``constraint_pre_base_name`` to all the existing APIs as an optional argument to add constraint name prefixes. 
2. Add ``formulation_info`` as an optional keyword argument to the ``construct_univariate_relaxation!`` function. If the ``milp`` flag is set to true it will try to reuse the partition variables used in ``formulation_info``. This feature will work as expected only when the partition points are the same - this is left to the user.
3. Adds a ``refine_partition!`` function to the API which exposes the interval bisection partition refinement scheme.