### PR TITLE
Reusing binary variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ PolyhedralRelaxations.jl Change Log
 - Add multilinear LP and MILP (SOS-2) relaxations 
 - Add multilinear linking constraints given multiple terms 
 - Add partition refinement schemes (:bisect_all, :bisect, :at_point, :non_uniform)
+- Add formulation reuse for univariate and bilinear relaxations
 
 ### v0.3.5 
 - Add compat entries for test dependencies

--- a/src/api.jl
+++ b/src/api.jl
@@ -113,7 +113,6 @@ new variables and constraints.
 - `formulation_info::FormulationInfo` : `FormulationInfo` for another bilinear function where the 
     variables that is partitioned has to be same on both; to enable partition variable reuse
         
-
 This function builds an incremental formulation, and currently supports more than 
 one partition only on one of the variables `x` or `y` and not on both. It will 
 throw an error when more than one partitions are provided on both variables. 
@@ -303,7 +302,6 @@ function refine_partition!(
 )::RefinementInfo
     if (point < partition[1] || point > partition[end])
         error("$point is not contained in the variable domain")
-        return RefinementInfo()
     end
     return _refine_partition!(
         partition,

--- a/src/api.jl
+++ b/src/api.jl
@@ -185,7 +185,10 @@ function construct_multilinear_relaxation!(
     z::JuMP.VariableRef,
     partitions::Dict{JuMP.VariableRef,Vector{T}} where {T<:Real};
     variable_pre_base_name::AbstractString = "",
-    binary_variables::Dict{JuMP.VariableRef,T} where {T<:Any} = Dict{JuMP.VariableRef,Any}()
+    binary_variables::Dict{JuMP.VariableRef,T} where {T<:Any} = Dict{
+        JuMP.VariableRef,
+        Any,
+    }(),
 )::FormulationInfo
     _validate(x, partitions)
     lp = all([length(it) == 2 for it in values(partitions)])

--- a/src/api.jl
+++ b/src/api.jl
@@ -50,7 +50,9 @@ Assume that:
 - `f_dash` is not equal at two consecutive elements of `x_partition`.
 
 This function builds an incremental formulation, which is the formulation
-presented in the paper.
+presented in the following reference:
+
+    Kaarthik Sundar, Sujeevraja Sanjeevi, and Harsha Nagarajan (2022). Sequence of Polyhedral Relaxations for Nonlinear Univariate Functions, https://arxiv.org/abs/2005.13445.
 """
 function construct_univariate_relaxation!(
     m::JuMP.Model,
@@ -163,6 +165,13 @@ of the domain of the `x` variables.
 # Optional Arguments
 - `variable_pre_base_name::AbstractString`: base_name that needs 
 to be added to the auxiliary variables for meaningful LP files
+- `binary_variables::Dict{JuMP.VariableRef,T} where {T<:Any}`: dictionary
+of binary partitioning variables corresponding to each variable. If this 
+dictionary has the binary variables corresponding to a variable involved 
+in the multilinear term, it will re-use them, else it will create new ones. 
+Everytime, this dictionary is populated with the binary variables that are created.
+So, the user only needs to create an empty dict the first time and keep passing 
+this to the function at every call.
 
 This function builds an lambda based SOS2 formulation for the piecewise polyhedral relaxation. 
 Reference information:
@@ -174,8 +183,9 @@ function construct_multilinear_relaxation!(
     m::JuMP.Model,
     x::Tuple,
     z::JuMP.VariableRef,
-    partitions::Dict{JuMP.VariableRef,Vector{T}} where {T<:Real},
+    partitions::Dict{JuMP.VariableRef,Vector{T}} where {T<:Real};
     variable_pre_base_name::AbstractString = "",
+    binary_variables::Dict{JuMP.VariableRef,T} where {T<:Any} = Dict{JuMP.VariableRef,Any}()
 )::FormulationInfo
     _validate(x, partitions)
     lp = all([length(it) == 2 for it in values(partitions)])
@@ -193,6 +203,7 @@ function construct_multilinear_relaxation!(
         x,
         z,
         partitions,
+        binary_variables,
         variable_pre_base_name,
     )
 end

--- a/src/bilinear_relaxation.jl
+++ b/src/bilinear_relaxation.jl
@@ -20,14 +20,10 @@ function _build_mccormick_relaxation!(
 
     formulation_info = FormulationInfo()
 
-    formulation_info.constraints[:lb_1] =
-        JuMP.@constraint(m, z >= x_lb * y + y_lb * x - x_lb * y_lb)
-    formulation_info.constraints[:lb_2] =
-        JuMP.@constraint(m, z >= x_ub * y + y_ub * x - x_ub * y_ub)
-    formulation_info.constraints[:ub_1] =
-        JuMP.@constraint(m, z <= x_lb * y + y_ub * x - x_lb * y_ub)
-    formulation_info.constraints[:ub_2] =
-        JuMP.@constraint(m, z <= x_ub * y + y_lb * x - x_ub * y_lb)
+    JuMP.@constraint(m, z >= x_lb * y + y_lb * x - x_lb * y_lb)
+    JuMP.@constraint(m, z >= x_ub * y + y_ub * x - x_ub * y_ub)
+    JuMP.@constraint(m, z <= x_lb * y + y_ub * x - x_lb * y_ub)
+    JuMP.@constraint(m, z <= x_ub * y + y_lb * x - x_ub * y_lb)
 
     return formulation_info
 end
@@ -85,7 +81,7 @@ function _build_bilinear_milp_relaxation!(
         )
 
     # add x constraints
-    formulation_info.constraints[:x] = JuMP.@constraint(
+    JuMP.@constraint(
         m,
         x ==
         origin_vs[1][1] + sum(
@@ -97,7 +93,7 @@ function _build_bilinear_milp_relaxation!(
     )
 
     # add y constraints
-    formulation_info.constraints[:y] = JuMP.@constraint(
+    JuMP.@constraint(
         m,
         y ==
         origin_vs[1][2] + sum(
@@ -109,7 +105,7 @@ function _build_bilinear_milp_relaxation!(
     )
 
     # add z constraints
-    formulation_info.constraints[:z_bin] = JuMP.@constraint(
+    JuMP.@constraint(
         m,
         z ==
         origin_vs[1][3] + sum(
@@ -121,17 +117,15 @@ function _build_bilinear_milp_relaxation!(
     )
 
     # add first delta constraint
-    formulation_info.constraints[:first_delta] =
-        JuMP.@constraint(m, delta_1[1] + delta_2[1] + delta_3[1] <= 1)
+    JuMP.@constraint(m, delta_1[1] + delta_2[1] + delta_3[1] <= 1)
 
     # add linking constraints between delta_1, delta_2 and z
-    formulation_info.constraints[:below_z] = JuMP.@constraint(
+    JuMP.@constraint(
         m,
         [i = 2:num_vars],
         delta_1[i] + delta_2[i] + delta_3[i] <= z_bin[i-1]
     )
-    formulation_info.constraints[:above_z] =
-        JuMP.@constraint(m, [i = 2:num_vars], z_bin[i-1] <= delta_3[i-1])
+    JuMP.@constraint(m, [i = 2:num_vars], z_bin[i-1] <= delta_3[i-1])
 
     return formulation_info
 end

--- a/src/bilinear_relaxation.jl
+++ b/src/bilinear_relaxation.jl
@@ -34,8 +34,8 @@ function _check_partition_variable_consistency(
     num_vars,
 )::Bool
     var = formulation_info.variables
-    if haskey(var, :z_bin)
-        (length(var[:z_bin]) == num_vars) && (return true)
+    if haskey(var, :bin)
+        (length(var[:bin]) == num_vars) && (return true)
     end
     return false
 end
@@ -90,14 +90,14 @@ function _build_bilinear_milp_relaxation!(
             base_name = variable_pre_base_name * "delta_3"
         )
     z_bin =
-        (is_consistent) ? reuse_variables[:z_bin] :
+        (is_consistent) ? reuse_variables[:bin] :
         JuMP.@variable(
             m,
             [1:num_vars],
             binary = true,
             base_name = variable_pre_base_name * "z"
         )
-    formulation_info.variables[:z_bin] = z_bin
+    formulation_info.variables[:bin] = z_bin
 
     # add x constraints
     JuMP.@constraint(

--- a/src/bilinear_relaxation.jl
+++ b/src/bilinear_relaxation.jl
@@ -17,14 +17,11 @@ function _build_mccormick_relaxation!(
 )::FormulationInfo
     x_lb, x_ub = _variable_domain(x)
     y_lb, y_ub = _variable_domain(y)
-
     formulation_info = FormulationInfo()
-
     JuMP.@constraint(m, z >= x_lb * y + y_lb * x - x_lb * y_lb)
     JuMP.@constraint(m, z >= x_ub * y + y_ub * x - x_ub * y_ub)
     JuMP.@constraint(m, z <= x_lb * y + y_ub * x - x_lb * y_ub)
     JuMP.@constraint(m, z <= x_ub * y + y_lb * x - x_ub * y_lb)
-
     return formulation_info
 end
 

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -28,7 +28,7 @@ end
 """
     silence!()
 
-Sets loglevel for PMD to :Error, silencing Info and Warn
+Sets loglevel for PR to :Error, silencing Info and Warn
 """
 function silence!()
     return set_logging_level!(:Error)
@@ -48,7 +48,7 @@ end
 """
     restore_global_logger!()
 
-Restores the global logger to its default state (before PMD was loaded)
+Restores the global logger to its default state (before PR was loaded)
 """
 function restore_global_logger!()
     Logging.global_logger(_DEFAULT_LOGGER)
@@ -70,7 +70,7 @@ end
 """
     _make_filtered_logger(level::Logging.LogLevel)
 
-Helper function to create the filtered logger for PMD
+Helper function to create the filtered logger for PR
 """
 function _make_filtered_logger(level)
     LoggingExtras.EarlyFilteredLogger(_LOGGER) do log

--- a/src/multilinear_relaxation.jl
+++ b/src/multilinear_relaxation.jl
@@ -119,8 +119,10 @@ function _build_multilinear_sos2_relaxation!(
 
     # multiplier and binary summation constraints
     JuMP.@constraint(m, sum(lambda) == 1)
+    formulation_info.constraints[:bin] = Dict{JuMP.VariableRef,Any}()
     for var in x
-        JuMP.@constraint(m, sum(bin[var]) == 1)
+        formulation_info.constraints[:bin][var] = JuMP.@constraint(
+            m, sum(bin[var]) == 1)
     end
 
     # convex combination constraints

--- a/src/multilinear_relaxation.jl
+++ b/src/multilinear_relaxation.jl
@@ -112,16 +112,21 @@ function _build_multilinear_sos2_relaxation!(
     bin = formulation_info.variables[:bin] = Dict{JuMP.VariableRef,Any}()
     for var in x
         if haskey(binary_variables, var)
-            vars = binary_variables[var]  
+            vars = binary_variables[var]
             if (length(vars) != length(partitions[var]) - 1)
-                error("number of binary variables for variable $var inconsistent with number of partitions")
-            end 
-            formulation_info.variables[:bin][var] = vars 
+                error(
+                    "number of binary variables for variable $var inconsistent with number of partitions",
+                )
+            end
+            formulation_info.variables[:bin][var] = vars
             continue
         end
-        binary_variables[var] = 
-        formulation_info.variables[:bin][var] = 
-                JuMP.@variable(m, [j in 1:(length(partitions[var])-1)], binary = true)
+        binary_variables[var] =
+            formulation_info.variables[:bin][var] = JuMP.@variable(
+                m,
+                [j in 1:(length(partitions[var])-1)],
+                binary = true
+            )
         # binary summation constraints
         JuMP.@constraint(m, sum(bin[var]) == 1)
     end

--- a/src/multilinear_relaxation.jl
+++ b/src/multilinear_relaxation.jl
@@ -121,8 +121,8 @@ function _build_multilinear_sos2_relaxation!(
     JuMP.@constraint(m, sum(lambda) == 1)
     formulation_info.constraints[:bin] = Dict{JuMP.VariableRef,Any}()
     for var in x
-        formulation_info.constraints[:bin][var] = JuMP.@constraint(
-            m, sum(bin[var]) == 1)
+        formulation_info.constraints[:bin][var] =
+            JuMP.@constraint(m, sum(bin[var]) == 1)
     end
 
     # convex combination constraints

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -42,13 +42,12 @@ function _build_univariate_lp_relaxation!(
     formulation_info.variables[:lambda] = lambda
 
     # add constraints 
-    formulation_info.constraints[:sum_lambda] =
-        JuMP.@constraint(m, sum(lambda) == 1)
-    formulation_info.constraints[:x] = JuMP.@constraint(
+    JuMP.@constraint(m, sum(lambda) == 1)
+    JuMP.@constraint(
         m,
         x == sum(lambda[i] * vertices[i][1] for i in 1:num_vars)
     )
-    formulation_info.constraints[:y] = JuMP.@constraint(
+    JuMP.@constraint(
         m,
         y == sum(lambda[i] * vertices[i][2] for i in 1:num_vars)
     )

--- a/src/univariate_lp_relaxation.jl
+++ b/src/univariate_lp_relaxation.jl
@@ -24,7 +24,8 @@ function _build_univariate_lp_relaxation!(
     x::JuMP.VariableRef,
     y::JuMP.VariableRef,
     univariate_function_data::UnivariateFunctionData,
-    pre_base_name::AbstractString,
+    variable_pre_base_name::AbstractString,
+    ::FormulationInfo,
 )::FormulationInfo
     vertices = _get_lp_relaxation_vertices(univariate_function_data)
     num_vars = length(vertices)
@@ -37,7 +38,7 @@ function _build_univariate_lp_relaxation!(
             [1:num_vars],
             lower_bound = 0.0,
             upper_bound = 1.0,
-            base_name = pre_base_name * "_lambda"
+            base_name = variable_pre_base_name * "_lambda"
         )
     formulation_info.variables[:lambda] = lambda
 

--- a/src/univariate_milp_relaxation.jl
+++ b/src/univariate_milp_relaxation.jl
@@ -51,14 +51,14 @@ function _build_univariate_milp_relaxation!(
             base_name = variable_pre_base_name * "delta_2"
         )
     z =
-        (is_consistent) ? reuse_variables[:z] :
+        (is_consistent) ? reuse_variables[:bin] :
         JuMP.@variable(
             m,
             [1:num_vars],
             binary = true,
             base_name = variable_pre_base_name * "_z"
         )
-    formulation_info.variables[:z] = z
+    formulation_info.variables[:bin] = z
 
     # add x constraints
     JuMP.@constraint(

--- a/src/univariate_milp_relaxation.jl
+++ b/src/univariate_milp_relaxation.jl
@@ -42,7 +42,7 @@ function _build_univariate_milp_relaxation!(
         )
 
     # add x constraints
-    formulation_info.constraints[:x] = JuMP.@constraint(
+    JuMP.@constraint(
         m,
         x ==
         sec_vs[1][1] + sum(
@@ -52,7 +52,7 @@ function _build_univariate_milp_relaxation!(
     )
 
     # add y constraints
-    formulation_info.constraints[:y] = JuMP.@constraint(
+    JuMP.@constraint(
         m,
         y ==
         sec_vs[1][2] + sum(
@@ -62,14 +62,10 @@ function _build_univariate_milp_relaxation!(
     )
 
     # add first delta constraint
-    formulation_info.constraints[:first_delta] =
-        JuMP.@constraint(m, delta_1[1] + delta_2[1] <= 1)
-
+    JuMP.@constraint(m, delta_1[1] + delta_2[1] <= 1)
     # add linking constraints between delta_1, delta_2 and z
-    formulation_info.constraints[:below_z] =
-        JuMP.@constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] <= z[i-1])
-    formulation_info.constraints[:above_z] =
-        JuMP.@constraint(m, [i = 2:num_vars], z[i-1] <= delta_2[i-1])
+    JuMP.@constraint(m, [i = 2:num_vars], delta_1[i] + delta_2[i] <= z[i-1])
+    JuMP.@constraint(m, [i = 2:num_vars], z[i-1] <= delta_2[i-1])
 
     return formulation_info
 end

--- a/src/univariate_milp_relaxation.jl
+++ b/src/univariate_milp_relaxation.jl
@@ -1,4 +1,16 @@
 """
+    _check_consistency(formulation_info, num_vars) 
+Checks consistency between provided variables and partition sizes 
+"""
+function _check_consistency(formulation_info::FormulationInfo, num_vars)::Bool
+    var = formulation_info.variables
+    if haskey(var, :z)
+        (length(var[:z]) == num_vars) && (return true)
+    end
+    return false
+end
+
+"""
     _build_univariate_milp_relaxation!(m,x,y,function_data,pre_base_name)
 
 Return a MILPRelaxation object with constraint and RHS information of the MILP
@@ -9,7 +21,8 @@ function _build_univariate_milp_relaxation!(
     x::JuMP.VariableRef,
     y::JuMP.VariableRef,
     univariate_function_data::UnivariateFunctionData,
-    pre_base_name::AbstractString,
+    variable_pre_base_name::AbstractString,
+    reuse::FormulationInfo,
 )::FormulationInfo
     sec_vs, tan_vs = _collect_vertices(univariate_function_data)
     formulation_info = FormulationInfo()
@@ -17,13 +30,17 @@ function _build_univariate_milp_relaxation!(
     # create variables
     num_vars = length(univariate_function_data.partition) - 1
 
+    reuse_variables = reuse.variables
+
+    is_consistent = _check_consistency(reuse, num_vars)
+
     delta_1 =
         formulation_info.variables[:delta_1] = JuMP.@variable(
             m,
             [1:num_vars],
             lower_bound = 0.0,
             upper_bound = 1.0,
-            base_name = pre_base_name * "delta_1"
+            base_name = variable_pre_base_name * "delta_1"
         )
     delta_2 =
         formulation_info.variables[:delta_2] = JuMP.@variable(
@@ -31,15 +48,17 @@ function _build_univariate_milp_relaxation!(
             [1:num_vars],
             lower_bound = 0.0,
             upper_bound = 1.0,
-            base_name = pre_base_name * "delta_2"
+            base_name = variable_pre_base_name * "delta_2"
         )
     z =
-        formulation_info.variables[:z] = JuMP.@variable(
+        (is_consistent) ? reuse_variables[:z] :
+        JuMP.@variable(
             m,
             [1:num_vars],
             binary = true,
-            base_name = pre_base_name * "z"
+            base_name = variable_pre_base_name * "_z"
         )
+    formulation_info.variables[:z] = z
 
     # add x constraints
     JuMP.@constraint(

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -15,11 +15,6 @@
     @test size(formulation_info.variables[:delta_1])[1] == 2
     @test size(formulation_info.variables[:delta_2])[1] == 2
     @test size(formulation_info.variables[:z])[1] == 2
-    @test haskey(formulation_info.constraints, :x)
-    @test haskey(formulation_info.constraints, :y)
-    @test haskey(formulation_info.constraints, :first_delta)
-    @test haskey(formulation_info.constraints, :below_z)
-    @test haskey(formulation_info.constraints, :above_z)
 end
 
 @testset "test LP relaxation API" begin
@@ -37,9 +32,6 @@ end
     )
 
     @test size(formulation_info.variables[:lambda])[1] == 4
-    @test haskey(formulation_info.constraints, :sum_lambda)
-    @test haskey(formulation_info.constraints, :x)
-    @test haskey(formulation_info.constraints, :y)
 end
 
 @testset "test bilinear relaxation API (McCormick)" begin

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -14,7 +14,7 @@
 
     @test size(formulation_info.variables[:delta_1])[1] == 2
     @test size(formulation_info.variables[:delta_2])[1] == 2
-    @test size(formulation_info.variables[:z])[1] == 2
+    @test size(formulation_info.variables[:bin])[1] == 2
 end
 
 @testset "test LP relaxation API" begin

--- a/test/multilinear_tests.jl
+++ b/test/multilinear_tests.jl
@@ -40,7 +40,13 @@
         for term in multilinear_terms
             z = first(term)
             vars = last(term)
-            construct_multilinear_relaxation!(m, vars, z, partitions, binary_variables = binary_variables)
+            construct_multilinear_relaxation!(
+                m,
+                vars,
+                z,
+                partitions,
+                binary_variables = binary_variables,
+            )
         end
         set_optimizer(m, milp_optimizer)
         optimize!(m)
@@ -103,7 +109,7 @@
                 last(term),
                 first(term),
                 partitions,
-                binary_variables = binary_variables
+                binary_variables = binary_variables,
             ) for term in multilinear_terms
         )
         gopt_value = instance.objective

--- a/test/multilinear_tests.jl
+++ b/test/multilinear_tests.jl
@@ -27,7 +27,7 @@
 
     @testset "test multilinear MILP relaxation" begin
         PR.silence!()
-        num_discretizations = [3, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+        num_discretizations = [3, 3, 2, 2, 2, 2, 2, 2, 2, 2]
         instance =
             create_multilinear_model(num_discretizations = num_discretizations)
         m = instance.model
@@ -36,10 +36,11 @@
         partitions = instance.partitions
         multilinear_terms = instance.multilinear_terms
         gopt_value = instance.objective
+        binary_variables = Dict{VariableRef,Any}()
         for term in multilinear_terms
             z = first(term)
             vars = last(term)
-            construct_multilinear_relaxation!(m, vars, z, partitions)
+            construct_multilinear_relaxation!(m, vars, z, partitions, binary_variables = binary_variables)
         end
         set_optimizer(m, milp_optimizer)
         optimize!(m)
@@ -95,12 +96,14 @@
         y = instance.variables[:y]
         partitions = instance.partitions
         multilinear_terms = instance.multilinear_terms
+        binary_variables = Dict{VariableRef,Any}()
         info = Dict(
             last(term) => construct_multilinear_relaxation!(
                 m,
                 last(term),
                 first(term),
                 partitions,
+                binary_variables = binary_variables
             ) for term in multilinear_terms
         )
         gopt_value = instance.objective

--- a/test/objective_tests.jl
+++ b/test/objective_tests.jl
@@ -43,7 +43,7 @@
             # Solve MILP relaxation.
             set_objective_sense(milp, s)
             optimize!(milp)
-            @test termination_status(milp) == MOI.OPTIMAL
+            @test termination_status(milp) == OPTIMAL
 
             # Verify that the solution is one of the candidate solutions in `sln_verts`.
             milp_obj = objective_value(milp)
@@ -63,7 +63,7 @@
             # same objective value as the MILP relaxation.
             relax_integrality(milp)
             optimize!(milp)
-            @test termination_status(milp) == MOI.OPTIMAL
+            @test termination_status(milp) == OPTIMAL
             lp1_obj = objective_value(milp)
             @test milp_obj ≈ lp1_obj atol = tol
 

--- a/test/tolerance_tests.jl
+++ b/test/tolerance_tests.jl
@@ -56,7 +56,7 @@ end
             error_tolerance = tol,
             num_additional_partitions = num_vars,
         )
-        @test length(formulation_info.variables[:z]) == num_base + num_vars
+        @test length(formulation_info.variables[:bin]) == num_base + num_vars
     end
 end
 


### PR DESCRIPTION
1. Track constraints that can be reused.  
2. Remove rest of the constraint references in `formulation_info`.
3. Reuse variables in all the MILP formulations