### PR TITLE
fix: remove DOCUMENTER_KEY from docs workflow, use GITHUB_TOKEN instead

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,5 +22,4 @@ jobs:
       - name: Build and Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
         run: julia --project=docs docs/make.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PolyhedralRelaxations = "2e741578-48fa-11ea-2d62-b52c946f73a0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,7 @@ using Documenter, PolyhedralRelaxations
 
 makedocs(
     sitename = "PolyhedralRelaxations",
+    repo = Documenter.Remotes.GitHub("sujeevraja", "PolyhedralRelaxations.jl"),
     format = Documenter.HTML(
         mathengine = Documenter.MathJax(),
         assets = [


### PR DESCRIPTION
## Summary
  - Remove `DOCUMENTER_KEY` from the documentation workflow — the secret exists in the repo but has
   an invalid SSH key, causing Documenter to fail with "Permission denied (publickey)"
  - With `DOCUMENTER_KEY` absent, Documenter falls back to `GITHUB_TOKEN` (HTTPS), which already
  has `contents: write` permission
  - Add `PolyhedralRelaxations` explicitly to `docs/Project.toml` deps for clarity

  ## Test plan
  - [ ] Confirm CI passes on this PR
  - [ ] Confirm docs deploy to gh-pages after merge to master
  - [ ] Optionally delete the `DOCUMENTER_KEY` secret from repo settings (Settings → Secrets →
  Actions) since it is no longer referenced